### PR TITLE
Key exchange support

### DIFF
--- a/crates/client/tests/common.rs
+++ b/crates/client/tests/common.rs
@@ -9,6 +9,7 @@ use miden_private_transport_node::{Node, NodeConfig, node::grpc::GrpcServerConfi
 use rand::Rng;
 use tokio::{task::JoinHandle, time::sleep};
 
+#[allow(dead_code)]
 pub const TAG_LOCALANY: u32 = 0xc000_0000;
 
 #[allow(dead_code)]

--- a/crates/client/tests/test_transport_key_exchange.rs
+++ b/crates/client/tests/test_transport_key_exchange.rs
@@ -1,0 +1,43 @@
+mod common;
+
+use self::common::*;
+
+#[tokio::test]
+async fn test_transport_key_exchange_aes() -> Result<(), Box<dyn std::error::Error>> {
+    let port = 9630;
+    let handle = spawn_test_server(port).await;
+
+    let (mut client0, _accid0, _) = test_client(port, EncryptionScheme::Aes).await;
+    let (mut client1, accid1, pubkey1) = test_client(port, EncryptionScheme::Aes).await;
+
+    // Register, fetch
+    client0.register_key(accid1, pubkey1.clone()).await?;
+    client1.fetch_key(accid1).await?;
+
+    // Verify key was stored
+    let stored_key = client1.get_key(&accid1).await?;
+    assert!(stored_key.is_some());
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transport_key_exchange_x25519() -> Result<(), Box<dyn std::error::Error>> {
+    let port = 9631;
+    let handle = spawn_test_server(port).await;
+
+    let (mut client0, _accid0, _) = test_client(port, EncryptionScheme::X25519).await;
+    let (mut client1, accid1, pubkey1) = test_client(port, EncryptionScheme::X25519).await;
+
+    // Register, fetch
+    client0.register_key(accid1, pubkey1.clone()).await?;
+    client1.fetch_key(accid1).await?;
+
+    // Verify key was stored
+    let stored_key = client1.get_key(&accid1).await?;
+    assert!(stored_key.is_some());
+
+    handle.abort();
+    Ok(())
+}

--- a/crates/proto/miden-private-transport.proto
+++ b/crates/proto/miden-private-transport.proto
@@ -4,12 +4,18 @@ package miden_private_transport;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
-import "miden-node/proto/proto/types/note.proto";
+import "types/note.proto";
+import "types/account.proto";
 
 // Note status enum
 enum NoteStatus {
     SENT = 0;
     DUPLICATE = 1;
+}
+
+enum RegisterKeyStatus {
+    ACCEPTED = 0;
+    REJECTED = 1;
 }
 
 message EncryptedNote {
@@ -21,6 +27,14 @@ message EncryptedNoteTimestamped {
     bytes header = 1;
     bytes encrypted_details = 2;
     google.protobuf.Timestamp timestamp = 3;
+}
+
+message EncryptionKey {
+    oneof value {
+        bytes aes256gcm = 1;
+        bytes x25519_pub = 2;
+        bytes other = 3;
+    }
 }
 
 // API request for sending a note
@@ -61,9 +75,30 @@ message StatsResponse {
 
 // Statistics for a specific tag
 message TagStats {
-    uint32 tag = 1;  // NoteTag as hex string
+    uint32 tag = 1;
     uint64 note_count = 2;
     google.protobuf.Timestamp last_activity = 3;
+}
+
+// API request for registering a key
+message RegisterKeyRequest {
+    account.AccountId account_id = 1;
+    EncryptionKey encryption_key = 2;
+}
+
+// API response for registering a key
+message RegisterKeyResponse {
+    RegisterKeyStatus status = 1;
+}
+
+// API request for getting a registered key
+message FetchKeyRequest {
+    account.AccountId account_id = 1;
+}
+
+// API response for getting a registered key
+message FetchKeyResponse {
+    optional EncryptionKey encryption_key = 1;
 }
 
 // gRPC service definition
@@ -79,4 +114,10 @@ service MidenPrivateTransport {
     
     // Get server statistics
     rpc Stats(google.protobuf.Empty) returns (StatsResponse);
+
+    // Register a key to the server
+    rpc RegisterKey(RegisterKeyRequest) returns (RegisterKeyResponse);
+    
+    // Get a registered key from the server
+    rpc FetchKey(FetchKeyRequest) returns (FetchKeyResponse);
 } 


### PR DESCRIPTION
Support to exchange encryption keys over the Transport Layer. 
An encryption key is associated with an Account ID.

Currently missing a way to validate account ID ownership in `register_key` requests.