### PR TITLE
Remove note tag replacement on client `send_note()`

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -151,7 +151,7 @@ async fn send_note(
         .map_err(|e| anyhow!("Invalid recipient address {recipient_address_bech32}: {e}"))?;
 
     // Send the note
-    client.send_note(note, Some(&address)).await?;
+    client.send_note(note, &address).await?;
     info!("Note sent successfully");
 
     Ok(())

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -7,7 +7,6 @@ pub mod types;
 // Re-exports
 use miden_objects::{
     address::Address,
-    note::NoteMetadata,
     utils::{Deserializable, Serializable},
 };
 
@@ -60,17 +59,9 @@ impl TransportLayerClient {
     /// the provided note' tag is updated.
     pub async fn send_note(
         &mut self,
-        mut note: Note,
-        address: Option<&Address>,
+        note: Note,
+        _address: &Address,
     ) -> Result<(NoteId, NoteStatus)> {
-        // Use the address note tag, if provided
-        if let Some(addr) = address {
-            let new_tag = addr.to_note_tag();
-            // Update tag
-            if new_tag != note.metadata().tag() {
-                note = note_with_tag(&note, new_tag)?;
-            }
-        }
         let header = *note.header();
         let details: NoteDetails = note.into();
         let details_bytes = details.to_bytes();
@@ -146,20 +137,4 @@ impl TransportLayerClient {
         // For now it does nothing.
         Ok(())
     }
-}
-
-fn note_with_tag(note: &Note, new_tag: NoteTag) -> Result<Note> {
-    let header = *note.header();
-    let details: NoteDetails = note.into();
-
-    let metadata = NoteMetadata::new(
-        header.metadata().sender(),
-        header.metadata().note_type(),
-        new_tag,
-        header.metadata().execution_hint(),
-        header.metadata().aux(),
-    )
-    .map_err(|e| Error::InvalidTag(format!("Invalid new tag {new_tag}: {e}")))?;
-
-    Ok(Note::new(details.assets().clone(), metadata, details.recipient().clone()))
 }

--- a/crates/client/tests/test_transport_basic.rs
+++ b/crates/client/tests/test_transport_basic.rs
@@ -21,7 +21,7 @@ async fn test_transport_note() -> std::result::Result<(), Box<dyn std::error::Er
     let note = mock_note_p2id_with_addresses(&adr0, &adr1);
     let header = *note.header();
 
-    let send_response = client0.send_note(note, Some(&adr1)).await?;
+    let send_response = client0.send_note(note, &adr1).await?;
     let (id, status) = send_response;
     assert_eq!(id, header.id());
     assert_eq!(status, NoteStatus::Sent);
@@ -58,13 +58,13 @@ async fn test_transport_different_tags() -> std::result::Result<(), Box<dyn std:
     let header1 = *note1.header();
 
     // Send Note0
-    let send_response = client0.send_note(note0, None).await?;
+    let send_response = client0.send_note(note0, &adr2).await?;
     let (id, status) = send_response;
     assert_eq!(id, header0.id());
     assert_eq!(status, NoteStatus::Sent);
 
     // Send Note1
-    let send_response = client1.send_note(note1, None).await?;
+    let send_response = client1.send_note(note1, &adr2).await?;
     let (id, status) = send_response;
     assert_eq!(id, header1.id());
     assert_eq!(status, NoteStatus::Sent);

--- a/crates/client/tests/test_transport_client_state.rs
+++ b/crates/client/tests/test_transport_client_state.rs
@@ -19,7 +19,7 @@ async fn test_transport_client_note_fetch_tracking()
 
     // Create and send a note
     let note = mock_note_p2id_with_tag_and_addresses(tag, &adr0, &adr1);
-    let (note_id, status) = client0.send_note(note, Some(&adr1)).await.unwrap();
+    let (note_id, status) = client0.send_note(note, &adr1).await.unwrap();
     assert!(matches!(status, NoteStatus::Sent));
 
     // Test note fetching recording
@@ -45,7 +45,7 @@ async fn test_transport_client_note_storage() -> std::result::Result<(), Box<dyn
 
     // Send a note
     let note = mock_note_p2id_with_addresses(&adr0, &adr1);
-    let (note_id, note_status) = client0.send_note(note, Some(&adr1)).await.unwrap();
+    let (note_id, note_status) = client0.send_note(note, &adr1).await.unwrap();
     assert!(matches!(note_status, NoteStatus::Sent));
 
     // Fetch


### PR DESCRIPTION
Removes the client `send_note()` tag replacement feature based on the recipient `Address` to align better with the final interface.

Closes #23.