### PR TITLE
`TransportLayerClient::fetch_notes()` return `Note`s

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -3,7 +3,12 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
-use miden_objects::{account::NetworkId, address::Address, note::Note, utils::Deserializable};
+use miden_objects::{
+    account::NetworkId,
+    address::Address,
+    note::{Note, NoteDetails},
+    utils::Deserializable,
+};
 use miden_private_transport_client::{
     Error, Result, TransportLayerClient,
     database::{Database, DatabaseConfig},
@@ -181,8 +186,13 @@ async fn fetch_notes(client: &mut TransportLayerClient, tag: u32) -> Result<()> 
 
     info!("Found {} notes", decrypted_notes.len());
 
-    for (i, (header, details)) in decrypted_notes.iter().enumerate() {
-        println!("Note {}:\n Header: {:?}\n Details: {:?}", i + 1, header, details);
+    for (i, note) in decrypted_notes.iter().enumerate() {
+        println!(
+            "Note {}:\n Header: {:?}\n Details: {:?}",
+            i + 1,
+            note.header(),
+            NoteDetails::from(note)
+        );
     }
 
     Ok(())

--- a/crates/rust-client/tests/test_transport_basic.rs
+++ b/crates/rust-client/tests/test_transport_basic.rs
@@ -28,9 +28,9 @@ async fn test_transport_note() -> std::result::Result<(), Box<dyn std::error::Er
 
     // Fetch note back
     let fetch_response = client1.fetch_notes(sent_tag).await?;
-    let infos = fetch_response;
-    assert_eq!(infos.len(), 1);
-    let (header, _details) = &infos[0];
+    let notes = fetch_response;
+    assert_eq!(notes.len(), 1);
+    let header = notes[0].header();
 
     let tag = header.metadata().tag();
     assert_eq!(tag, sent_tag);
@@ -70,20 +70,24 @@ async fn test_transport_different_tags() -> std::result::Result<(), Box<dyn std:
     assert_eq!(status, NoteStatus::Sent);
 
     // Fetch Tag0 (Note0)
-    let fetch_response = client2.fetch_notes(sent_tag0).await?;
-    let infos = fetch_response;
-    assert_eq!(infos.len(), 1);
-    let (header, _details) = &infos[0];
-    let tag = header.metadata().tag();
-    assert_eq!(tag, sent_tag0);
+    {
+        let fetch_response = client2.fetch_notes(sent_tag0).await?;
+        let fetched_notes = fetch_response;
+        assert_eq!(fetched_notes.len(), 1);
+        let header = fetched_notes[0].header();
+        let tag = header.metadata().tag();
+        assert_eq!(tag, sent_tag0);
+    }
 
     // Fetch Tag1 (Note1)
-    let fetch_response = client2.fetch_notes(sent_tag1).await?;
-    let infos = fetch_response;
-    assert_eq!(infos.len(), 1);
-    let (header, _details) = &infos[0];
-    let tag = header.metadata().tag();
-    assert_eq!(tag, sent_tag1);
+    {
+        let fetch_response = client2.fetch_notes(sent_tag1).await?;
+        let fetched_notes = fetch_response;
+        assert_eq!(fetched_notes.len(), 1);
+        let header = fetched_notes[0].header();
+        let tag = header.metadata().tag();
+        assert_eq!(tag, sent_tag1);
+    }
 
     handle.abort();
     Ok(())


### PR DESCRIPTION
Makes the main client return the full note, rather than a split version.