### PR TITLE
Move timestamp-based pagination logic to `TransportLayerClient`

### DIFF
--- a/crates/rust-client/src/grpc.rs
+++ b/crates/rust-client/src/grpc.rs
@@ -6,7 +6,6 @@ compile_error!("The `web-tonic` feature is only supported when targeting wasm32.
 
 use alloc::{
     boxed::Box,
-    collections::BTreeMap,
     string::{String, ToString},
     vec::Vec,
 };
@@ -46,8 +45,6 @@ type Service = tonic_web_wasm_client::Client;
 pub struct GrpcClient {
     client: MidenPrivateTransportClient<Service>,
     health_client: HealthClient<Service>,
-    // Last fetched timestamp
-    lts: BTreeMap<NoteTag, DateTime<Utc>>,
 }
 
 impl GrpcClient {
@@ -63,9 +60,8 @@ impl GrpcClient {
         let timeout_channel = Timeout::new(channel, timeout);
         let health_client = HealthClient::new(timeout_channel.clone());
         let client = MidenPrivateTransportClient::new(timeout_channel);
-        let lts = BTreeMap::new();
 
-        Ok(Self { client, health_client, lts })
+        Ok(Self { client, health_client })
     }
 
     #[cfg(feature = "web-tonic")]
@@ -73,9 +69,8 @@ impl GrpcClient {
         let client = tonic_web_wasm_client::Client::new(endpoint);
         let health_client = HealthClient::new(client.clone());
         let client = MidenPrivateTransportClient::new(client.clone());
-        let lts = BTreeMap::new();
 
-        Ok(Self { client, health_client, lts })
+        Ok(Self { client, health_client })
     }
 
     pub async fn send_note(&mut self, header: NoteHeader, details: Vec<u8>) -> Result<NoteId> {
@@ -99,13 +94,16 @@ impl GrpcClient {
         Ok(note_id)
     }
 
-    pub async fn fetch_notes(&mut self, tag: NoteTag) -> Result<Vec<NoteInfo>> {
-        let ts = self.lts.get(&tag).copied().unwrap_or(DateTime::from_timestamp(0, 0).unwrap());
+    pub async fn fetch_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Vec<NoteInfo>> {
         let request = FetchNotesRequest {
             tag: tag.as_u32(),
             timestamp: Some(prost_types::Timestamp {
-                seconds: ts.timestamp(),
-                nanos: ts
+                seconds: timestamp.timestamp(),
+                nanos: timestamp
                     .timestamp_subsec_nanos()
                     .try_into()
                     .map_err(|_| Error::Internal("Timestamp nanoseconds too large".to_string()))?,
@@ -123,7 +121,6 @@ impl GrpcClient {
 
         // Convert protobuf notes to internal format and track the most recent received timestamp
         let mut notes = Vec::new();
-        let mut latest_received_at = ts;
 
         for pts_note in response.notes {
             let note = pts_note
@@ -139,11 +136,6 @@ impl GrpcClient {
                 Utc::now() // Fallback to current time if timestamp is missing
             };
 
-            // Update the latest received timestamp
-            if received_at > latest_received_at {
-                latest_received_at = received_at;
-            }
-
             notes.push(NoteInfo {
                 header,
                 details: note.details,
@@ -151,20 +143,19 @@ impl GrpcClient {
             });
         }
 
-        // Update the last timestamp to the most recent received timestamp
-        self.lts.insert(tag, latest_received_at);
-
         Ok(notes)
     }
 
-    pub async fn stream_notes(&mut self, tag: NoteTag) -> Result<NoteStreamAdapter> {
-        let ts = self.lts.get(&tag).copied().unwrap_or(DateTime::from_timestamp(0, 0).unwrap());
-
+    pub async fn stream_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<NoteStreamAdapter> {
         let request = StreamNotesRequest {
             tag: tag.as_u32(),
             timestamp: Some(prost_types::Timestamp {
-                seconds: ts.timestamp(),
-                nanos: ts
+                seconds: timestamp.timestamp(),
+                nanos: timestamp
                     .timestamp_subsec_nanos()
                     .try_into()
                     .map_err(|_| Error::Internal("Timestamp nanoseconds too large".to_string()))?,
@@ -206,12 +197,20 @@ impl super::TransportClient for GrpcClient {
         Ok(note_id)
     }
 
-    async fn fetch_notes(&mut self, tag: NoteTag) -> Result<Vec<crate::types::NoteInfo>> {
-        self.fetch_notes(tag).await
+    async fn fetch_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Vec<crate::types::NoteInfo>> {
+        self.fetch_notes(tag, timestamp).await
     }
 
-    async fn stream_notes(&mut self, tag: NoteTag) -> Result<Box<dyn NoteStream>> {
-        let stream = self.stream_notes(tag).await?;
+    async fn stream_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Box<dyn NoteStream>> {
+        let stream = self.stream_notes(tag, timestamp).await?;
         Ok(Box::new(stream))
     }
 }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[macro_use]
 extern crate alloc;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -14,6 +14,7 @@ pub mod grpc;
 pub mod logging;
 pub mod types;
 
+use chrono::{DateTime, Utc};
 use futures::Stream;
 use miden_objects::{
     address::Address,
@@ -36,11 +37,19 @@ pub trait TransportClient: Send + Sync {
     /// Send a note with optionally encrypted details
     async fn send_note(&mut self, header: NoteHeader, details: Vec<u8>) -> Result<NoteId>;
 
-    /// Fetch all notes for a given tag
-    async fn fetch_notes(&mut self, tag: NoteTag) -> Result<Vec<NoteInfo>>;
+    /// Fetch all notes timestamped after a given timestamp for a given tag
+    async fn fetch_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Vec<NoteInfo>>;
 
     /// Stream notes for a given tag
-    async fn stream_notes(&mut self, tag: NoteTag) -> Result<Box<dyn NoteStream>>;
+    async fn stream_notes(
+        &mut self,
+        tag: NoteTag,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Box<dyn NoteStream>>;
 }
 
 /// Stream trait for note streaming
@@ -53,6 +62,8 @@ pub struct TransportLayerClient {
     database: Database,
     /// Owned addresses
     addresses: Vec<Address>,
+    /// Last fetched timestamp
+    lts: BTreeMap<NoteTag, DateTime<Utc>>,
 }
 
 impl TransportLayerClient {
@@ -61,7 +72,13 @@ impl TransportLayerClient {
         database: Database,
         addresses: Vec<Address>,
     ) -> Self {
-        Self { transport_client, database, addresses }
+        let lts = BTreeMap::new();
+        Self {
+            transport_client,
+            database,
+            addresses,
+            lts,
+        }
     }
 
     /// Send a note to a recipient
@@ -77,9 +94,11 @@ impl TransportLayerClient {
 
     /// Fetch and decrypt notes for a tag
     pub async fn fetch_notes(&mut self, tag: NoteTag) -> Result<Vec<Note>> {
-        let infos = self.transport_client.fetch_notes(tag).await?;
+        let ts = self.lts.get(&tag).copied().unwrap_or(DateTime::from_timestamp(0, 0).unwrap());
+        let infos = self.transport_client.fetch_notes(tag, ts).await?;
         let mut decrypted_notes = Vec::new();
 
+        let mut latest_ts = ts;
         for info in infos {
             // Check if we've already fetched this note
             if !self.database.note_fetched(&info.header.id()).await? {
@@ -99,14 +118,23 @@ impl TransportLayerClient {
                 // Store the encrypted note
                 self.database.store_note(&info.header, &info.details, info.created_at).await?;
             }
+
+            // Update the latest received timestamp
+            if info.created_at > latest_ts {
+                latest_ts = info.created_at;
+            }
         }
+
+        // Update the last timestamp to the most recent received timestamp
+        self.lts.insert(tag, latest_ts);
 
         Ok(decrypted_notes)
     }
 
     /// Continuously fetch notes
     pub async fn stream_notes(&mut self, tag: NoteTag) -> Result<Box<dyn NoteStream>> {
-        self.transport_client.stream_notes(tag).await
+        let ts = self.lts.get(&tag).copied().unwrap_or(DateTime::from_timestamp(0, 0).unwrap());
+        self.transport_client.stream_notes(tag, ts).await
     }
 
     /// Adds an owned address

--- a/crates/rust-client/src/types.rs
+++ b/crates/rust-client/src/types.rs
@@ -118,8 +118,7 @@ pub fn random_note_id() -> NoteId {
     NoteId::new(recipient, asset_commitment)
 }
 
-pub const TEST_TAG: u32 = 3_221_225_472;
-pub fn test_note_header() -> NoteHeader {
+pub fn test_note_header(tag: NoteTag) -> NoteHeader {
     use miden_objects::{
         Felt,
         account::AccountId,
@@ -130,7 +129,6 @@ pub fn test_note_header() -> NoteHeader {
     let id = random_note_id();
     let sender = AccountId::try_from(ACCOUNT_ID_MAX_ZEROES).unwrap();
     let note_type = NoteType::Private;
-    let tag = NoteTag::from_account_id(sender);
     let aux = Felt::try_from(0xffff_ffff_0000_0000u64).unwrap();
     let execution_hint = NoteExecutionHint::None;
 


### PR DESCRIPTION
Moves the pagination logic to outside the `TransportClient`.