### PR TITLE
Move towards cursor-based pagination (timestamp-based server-side)

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -207,11 +207,11 @@ async fn stream_notes(client: &mut TransportLayerClient, tag: u32) -> Result<()>
             Ok(notes) => {
                 for (i, note_info) in notes.iter().enumerate() {
                     println!(
-                        "Note {}:\n Header: {:?}\n Details: {} bytes\n Created: {:?}\n",
+                        "Note {}:\n Header: {:?}\n Details: {} bytes\n Cursor: {}\n",
                         i + 1,
                         note_info.header,
                         note_info.details.len(),
-                        note_info.created_at
+                        note_info.cursor
                     );
                 }
             },

--- a/crates/proto/miden-private-transport.proto
+++ b/crates/proto/miden-private-transport.proto
@@ -15,11 +15,11 @@ message TransportNote {
     bytes details = 2;
 }
 
-message TransportNoteTimestamped {
+message TransportNotePg {
     // Note
     TransportNote note = 1;
-    // Transport Layer timestamp
-    google.protobuf.Timestamp timestamp = 2;
+    // Transport Layer pagination
+    fixed64 cursor = 2;
 }
 
 // API request for sending a note
@@ -28,30 +28,28 @@ message SendNoteRequest {
 }
 
 // API response for sending a note
-message SendNoteResponse {
-    string id = 1;  // NoteId as hex string
-}
+message SendNoteResponse { }
 
 // API request for fetching notes
 message FetchNotesRequest {
     fixed32 tag = 1;
-    google.protobuf.Timestamp timestamp = 2;
+    fixed64 cursor = 2;
 }
 
 // API response for fetching notes
 message FetchNotesResponse {
-    repeated TransportNoteTimestamped notes = 1;
+    repeated TransportNotePg notes = 1;
 }
 
 // API request for streaming notes
 message StreamNotesRequest {
     fixed32 tag = 1;
-    google.protobuf.Timestamp timestamp = 2;
+    fixed64 cursor = 2;
 }
 
 // API response for streaming notes updates
 message StreamNotesUpdate {
-    repeated TransportNoteTimestamped notes = 1;
+    repeated TransportNotePg notes = 1;
 }
 
 // Server statistics

--- a/crates/proto/src/generated/miden_private_transport.rs
+++ b/crates/proto/src/generated/miden_private_transport.rs
@@ -11,13 +11,13 @@ pub struct TransportNote {
     pub details: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransportNoteTimestamped {
+pub struct TransportNotePg {
     /// Note
     #[prost(message, optional, tag = "1")]
     pub note: ::core::option::Option<TransportNote>,
-    /// Transport Layer timestamp
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API request for sending a note
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -26,39 +26,35 @@ pub struct SendNoteRequest {
     pub note: ::core::option::Option<TransportNote>,
 }
 /// API response for sending a note
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SendNoteResponse {
-    /// NoteId as hex string
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SendNoteResponse {}
 /// API request for fetching notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct FetchNotesRequest {
     #[prost(fixed32, tag = "1")]
     pub tag: u32,
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API response for fetching notes
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesResponse {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNoteTimestamped>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
 }
 /// API request for streaming notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct StreamNotesRequest {
     #[prost(fixed32, tag = "1")]
     pub tag: u32,
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API response for streaming notes updates
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamNotesUpdate {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNoteTimestamped>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
 }
 /// Server statistics
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto/src/generated_transport/miden_private_transport.rs
+++ b/crates/proto/src/generated_transport/miden_private_transport.rs
@@ -11,13 +11,13 @@ pub struct TransportNote {
     pub details: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransportNoteTimestamped {
+pub struct TransportNotePg {
     /// Note
     #[prost(message, optional, tag = "1")]
     pub note: ::core::option::Option<TransportNote>,
-    /// Transport Layer timestamp
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API request for sending a note
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -26,39 +26,35 @@ pub struct SendNoteRequest {
     pub note: ::core::option::Option<TransportNote>,
 }
 /// API response for sending a note
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SendNoteResponse {
-    /// NoteId as hex string
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SendNoteResponse {}
 /// API request for fetching notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct FetchNotesRequest {
     #[prost(fixed32, tag = "1")]
     pub tag: u32,
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API response for fetching notes
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesResponse {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNoteTimestamped>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
 }
 /// API request for streaming notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct StreamNotesRequest {
     #[prost(fixed32, tag = "1")]
     pub tag: u32,
-    #[prost(message, optional, tag = "2")]
-    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API response for streaming notes updates
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamNotesUpdate {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNoteTimestamped>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
 }
 /// Server statistics
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/database/idxdb/js/notes.js
+++ b/crates/rust-client/src/database/idxdb/js/notes.js
@@ -116,6 +116,7 @@ export function getStoredNotesForTag(tag) {
     });
 }
 
+
 // Record that a note has been fetched
 export function recordFetchedNote(noteId, tag, fetchedAt) {
     return new Promise(async (resolve, reject) => {

--- a/crates/rust-client/src/database/idxdb/mod.rs
+++ b/crates/rust-client/src/database/idxdb/mod.rs
@@ -7,6 +7,8 @@
 //! **Note:** This implementation is only available when targeting WebAssembly with the `idxdb`
 //! feature enabled.
 
+#![allow(missing_docs)]
+
 use alloc::{boxed::Box, vec::Vec};
 
 use chrono::{DateTime, Utc};

--- a/crates/rust-client/src/database/idxdb/note/js_bindings.rs
+++ b/crates/rust-client/src/database/idxdb/note/js_bindings.rs
@@ -14,7 +14,7 @@ extern "C" {
         note_id: Vec<u8>,
         header: Vec<u8>,
         details: Vec<u8>,
-        created_at: String,
+        created_at: i64,
     ) -> js_sys::Promise;
 
     #[wasm_bindgen(js_name = getStoredNote)]

--- a/crates/rust-client/src/database/idxdb/note/models.rs
+++ b/crates/rust-client/src/database/idxdb/note/models.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct StoredNoteIdxdbObject {
     pub header: Vec<u8>,
     pub details: Vec<u8>,
-    pub created_at: String,
+    pub created_at: i64,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/rust-client/src/database/sqlite/schema.sql
+++ b/crates/rust-client/src/database/sqlite/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS stored_notes (
     tag INTEGER NOT NULL,
     header BLOB NOT NULL,
     details BLOB NOT NULL,
-    created_at TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
 
     PRIMARY KEY (note_id)
 ) STRICT;

--- a/crates/rust-client/src/types.rs
+++ b/crates/rust-client/src/types.rs
@@ -23,8 +23,8 @@ pub struct StoredNote {
     pub header: NoteHeader,
     /// Note details, can be encrypted
     pub details: Vec<u8>,
-    /// Note reference timestamp
-    pub created_at: DateTime<Utc>,
+    /// Note reference cursor
+    pub cursor: u64,
     /// Note fetched-at timestamp
     pub received_at: DateTime<Utc>,
 }
@@ -40,8 +40,8 @@ pub struct NoteInfo {
     pub header: NoteHeader,
     /// Note details, can be encrypted
     pub details: Vec<u8>,
-    /// Note reference timestamp
-    pub created_at: DateTime<Utc>,
+    /// Note reference cursor
+    pub cursor: u64,
 }
 
 /// Helper converter from [`prost_types::Timestamp`] to `DateTime<Utc>`

--- a/crates/rust-client/tests/test_transport_basic.rs
+++ b/crates/rust-client/tests/test_transport_basic.rs
@@ -19,11 +19,9 @@ async fn test_transport_note() -> std::result::Result<(), Box<dyn std::error::Er
     let sent_tag = adr1.to_note_tag();
 
     let note = mock_note_p2id_with_addresses(&adr0, &adr1);
-    let header = *note.header();
+    let _header = *note.header();
 
-    let send_response = client0.send_note(note, &adr1).await?;
-    let id = send_response;
-    assert_eq!(id, header.id());
+    client0.send_note(note, &adr1).await?;
 
     // Fetch note back
     let fetch_response = client1.fetch_notes(sent_tag).await?;
@@ -53,18 +51,14 @@ async fn test_transport_different_tags() -> std::result::Result<(), Box<dyn std:
     let note0 = mock_note_p2id_with_tag_and_addresses(sent_tag0, &adr0, &adr2);
     let note1 = mock_note_p2id_with_tag_and_addresses(sent_tag1, &adr1, &adr2);
 
-    let header0 = *note0.header();
-    let header1 = *note1.header();
+    let _header0 = *note0.header();
+    let _header1 = *note1.header();
 
     // Send Note0
-    let send_response = client0.send_note(note0, &adr2).await?;
-    let id = send_response;
-    assert_eq!(id, header0.id());
+    client0.send_note(note0, &adr2).await?;
 
     // Send Note1
-    let send_response = client1.send_note(note1, &adr2).await?;
-    let id = send_response;
-    assert_eq!(id, header1.id());
+    client1.send_note(note1, &adr2).await?;
 
     // Fetch Tag0 (Note0)
     {

--- a/crates/rust-client/tests/test_transport_client_state.rs
+++ b/crates/rust-client/tests/test_transport_client_state.rs
@@ -20,8 +20,7 @@ async fn test_transport_client_note_fetch_tracking()
     // Create and send a note
     let note = mock_note_p2id_with_tag_and_addresses(tag, &adr0, &adr1);
     let note_id = note.id();
-    let rx_note_id = client0.send_note(note, &adr1).await.unwrap();
-    assert_eq!(rx_note_id, note_id);
+    client0.send_note(note, &adr1).await.unwrap();
 
     // Test note fetching recording
 
@@ -47,8 +46,7 @@ async fn test_transport_client_note_storage() -> std::result::Result<(), Box<dyn
     // Send a note
     let note = mock_note_p2id_with_addresses(&adr0, &adr1);
     let note_id = note.id();
-    let rx_note_id = client0.send_note(note, &adr1).await.unwrap();
-    assert_eq!(rx_note_id, rx_note_id);
+    client0.send_note(note, &adr1).await.unwrap();
 
     // Fetch
     let sent_tag = adr1.to_note_tag();

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib"]
 default = []
 
 [dependencies]
-miden-private-transport-client = { features = ["idxdb", "web-tonic"], workspace = true }
+miden-private-transport-client = { features = ["idxdb", "testing", "web-tonic"], workspace = true }
 
 # Miden dependencies
 miden-client  = { workspace = true }

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -51,12 +51,14 @@ impl TransportLayerWebClient {
 
         let native_note: miden_objects::note::Note = note.into();
         let native_address: miden_objects::address::Address = address.into();
+        let note_id = native_note.id();
 
-        let note_id = inner
+        inner
             .send_note(native_note, &native_address)
             .await
             .map_err(|e| JsValue::from_str(&format!("Failed to send note: {:?}", e)))?;
 
+        // Return the note ID from the note that was sent
         Ok(note_id.into())
     }
 

--- a/crates/web-client/src/utils.rs
+++ b/crates/web-client/src/utils.rs
@@ -1,6 +1,6 @@
 use miden_client::utils::{Deserializable, Serializable};
 use miden_objects::utils::SliceReader;
-use miden_private_transport_client::types::{
+use miden_private_transport_client::test_utils::{
     mock_address as rc_mock_address,
     mock_note_p2id_with_addresses as rc_mock_note_p2id_with_addresses,
 };


### PR DESCRIPTION
Move to cursor-based pagination. Server-side we still employ a timestamp serialized as an integer, serving as the cursor.