### PR TITLE
Batched-tags note fetching

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crates/proto/miden-node"]
-	path = crates/proto/miden-node
-	url = https://github.com/0xMiden/miden-node.git

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -182,7 +182,7 @@ async fn send_note(
 
 async fn fetch_notes(client: &mut TransportLayerClient, tag: u32) -> Result<()> {
     // Fetch notes
-    let decrypted_notes = client.fetch_notes(tag.into()).await?;
+    let decrypted_notes = client.fetch_notes(&[tag.into()]).await?;
 
     info!("Found {} notes", decrypted_notes.len());
 

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -1,13 +1,12 @@
 mod streaming;
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use chrono::Utc;
 use miden_objects::utils::Deserializable;
 use miden_private_transport_proto::miden_private_transport::{
     FetchNotesRequest, FetchNotesResponse, SendNoteRequest, SendNoteResponse, StatsResponse,
-    StreamNotesRequest, TransportNotePg,
-    miden_private_transport_server::MidenPrivateTransportServer,
+    StreamNotesRequest, TransportNote, miden_private_transport_server::MidenPrivateTransportServer,
 };
 use rand::Rng;
 use tokio::sync::mpsc;
@@ -155,30 +154,38 @@ impl miden_private_transport_proto::miden_private_transport::miden_private_trans
         let timer = self.metrics.grpc_fetch_notes_request();
 
         let request_data = request.into_inner();
-        let tag = request_data.tag;
+        let tags = request_data.tags.into_iter().collect::<BTreeSet<_>>();
         let cursor = request_data.cursor;
 
-        let notes = self
-            .database
-            .fetch_notes(tag.into(), cursor)
-            .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
+        let mut rcursor = 0;
+        let mut proto_notes = vec![];
+        for tag in tags {
+            let stored_notes = self
+                .database
+                .fetch_notes(tag.into(), cursor)
+                .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
-        // Convert to protobuf format
-        let proto_notes: Result<Vec<_>, _> = notes
-            .into_iter()
-            .map(TransportNotePg::try_from)
-            .collect();
-        let proto_notes = proto_notes.map_err(|e| tonic::Status::internal(format!("Failed converting into proto TransportNotePg: {e}")))?;
+            for stored_note in &stored_notes {
+                let ts_cursor: u64 = stored_note
+                    .created_at
+                    .timestamp_micros()
+                    .try_into()
+                    .map_err(|_| tonic::Status::internal("Timestamp too large for cursor"))?;
+                rcursor = rcursor.max(ts_cursor);
+            }
+
+            proto_notes.extend(stored_notes.into_iter().map(TransportNote::from));
+        }
 
         timer.finish("ok");
 
-        let proto_notes_size = proto_notes.iter().map(|pgnote| pgnote.note.as_ref().map_or(0, |pnote| (pnote.header.len() + pnote.details.len()) as u64)).sum();
+        let proto_notes_size = proto_notes.iter().map(|pnote| (pnote.header.len() + pnote.details.len()) as u64).sum();
         self.metrics.grpc_fetch_notes_response(
             proto_notes.len() as u64,
             proto_notes_size,
         );
 
-        Ok(tonic::Response::new(FetchNotesResponse { notes: proto_notes }))
+        Ok(tonic::Response::new(FetchNotesResponse { notes: proto_notes, cursor }))
     }
 
     type StreamNotesStream = Sub;
@@ -188,11 +195,11 @@ impl miden_private_transport_proto::miden_private_transport::miden_private_trans
         request: tonic::Request<StreamNotesRequest>,
     ) -> Result<tonic::Response<Self::StreamNotesStream>, tonic::Status> {
         let request_data = request.into_inner();
-        let tag = request_data.tag;
+        let tag = request_data.tag.into();
         let id = rand::rng().random();
         let (sub_tx, sub_rx) = mpsc::channel(32);
-        let sub = Sub::new(id, tag.into(), sub_rx, self.streamer.tx.clone());
-        let subf = Subface::new(id, tag.into(), sub_tx);
+        let sub = Sub::new(id, tag, sub_rx, self.streamer.tx.clone());
+        let subf = Subface::new(id, tag, sub_tx);
         self.streamer.tx.try_send(StreamerMessage::AddSub(subf))
                     .map_err(|e| tonic::Status::internal(format!("Failed sending internal streamer message: {e}")))?;
 

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -20,22 +20,12 @@ pub struct StoredNote {
     pub created_at: DateTime<Utc>,
 }
 
-impl TryFrom<StoredNote> for miden_private_transport_proto::TransportNotePg {
-    type Error = anyhow::Error;
-
-    fn try_from(snote: StoredNote) -> Result<Self, Self::Error> {
-        let pnote = miden_private_transport_proto::TransportNote {
+impl From<StoredNote> for miden_private_transport_proto::TransportNote {
+    fn from(snote: StoredNote) -> Self {
+        Self {
             header: snote.header.to_bytes(),
             details: snote.details,
-        };
-
-        let cursor = snote
-            .created_at
-            .timestamp_micros()
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("Timestamp too large for cursor"))?;
-
-        Ok(Self { note: Some(pnote), cursor })
+        }
     }
 }
 

--- a/crates/proto/miden-private-transport.proto
+++ b/crates/proto/miden-private-transport.proto
@@ -4,7 +4,6 @@ package miden_private_transport;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
-import "types/note.proto";
 
 // A Note exchanged over the Transport Layer.
 // Includes the full header for NoteId, NoteTag access.
@@ -13,13 +12,6 @@ message TransportNote {
     bytes header = 1;
     // NoteDetails, can be encrypted
     bytes details = 2;
-}
-
-message TransportNotePg {
-    // Note
-    TransportNote note = 1;
-    // Transport Layer pagination
-    fixed64 cursor = 2;
 }
 
 // API request for sending a note
@@ -32,13 +24,15 @@ message SendNoteResponse { }
 
 // API request for fetching notes
 message FetchNotesRequest {
-    fixed32 tag = 1;
+    repeated fixed32 tags = 1;
     fixed64 cursor = 2;
 }
 
 // API response for fetching notes
 message FetchNotesResponse {
-    repeated TransportNotePg notes = 1;
+    repeated TransportNote notes = 1;
+    // Transport Layer pagination
+    fixed64 cursor = 2;
 }
 
 // API request for streaming notes
@@ -49,7 +43,9 @@ message StreamNotesRequest {
 
 // API response for streaming notes updates
 message StreamNotesUpdate {
-    repeated TransportNotePg notes = 1;
+    repeated TransportNote notes = 1;
+    // Transport Layer pagination
+    fixed64 cursor = 2;
 }
 
 // Server statistics

--- a/crates/proto/src/generated/miden_private_transport.rs
+++ b/crates/proto/src/generated/miden_private_transport.rs
@@ -10,15 +10,6 @@ pub struct TransportNote {
     #[prost(bytes = "vec", tag = "2")]
     pub details: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransportNotePg {
-    /// Note
-    #[prost(message, optional, tag = "1")]
-    pub note: ::core::option::Option<TransportNote>,
-    /// Transport Layer pagination
-    #[prost(fixed64, tag = "2")]
-    pub cursor: u64,
-}
 /// API request for sending a note
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendNoteRequest {
@@ -29,10 +20,10 @@ pub struct SendNoteRequest {
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SendNoteResponse {}
 /// API request for fetching notes
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesRequest {
-    #[prost(fixed32, tag = "1")]
-    pub tag: u32,
+    #[prost(fixed32, repeated, tag = "1")]
+    pub tags: ::prost::alloc::vec::Vec<u32>,
     #[prost(fixed64, tag = "2")]
     pub cursor: u64,
 }
@@ -40,7 +31,10 @@ pub struct FetchNotesRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesResponse {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNote>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API request for streaming notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -54,7 +48,10 @@ pub struct StreamNotesRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamNotesUpdate {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNote>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// Server statistics
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/proto/src/generated_transport/miden_private_transport.rs
+++ b/crates/proto/src/generated_transport/miden_private_transport.rs
@@ -10,15 +10,6 @@ pub struct TransportNote {
     #[prost(bytes = "vec", tag = "2")]
     pub details: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransportNotePg {
-    /// Note
-    #[prost(message, optional, tag = "1")]
-    pub note: ::core::option::Option<TransportNote>,
-    /// Transport Layer pagination
-    #[prost(fixed64, tag = "2")]
-    pub cursor: u64,
-}
 /// API request for sending a note
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendNoteRequest {
@@ -29,10 +20,10 @@ pub struct SendNoteRequest {
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SendNoteResponse {}
 /// API request for fetching notes
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesRequest {
-    #[prost(fixed32, tag = "1")]
-    pub tag: u32,
+    #[prost(fixed32, repeated, tag = "1")]
+    pub tags: ::prost::alloc::vec::Vec<u32>,
     #[prost(fixed64, tag = "2")]
     pub cursor: u64,
 }
@@ -40,7 +31,10 @@ pub struct FetchNotesRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchNotesResponse {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNote>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// API request for streaming notes
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -54,7 +48,10 @@ pub struct StreamNotesRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamNotesUpdate {
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<TransportNotePg>,
+    pub notes: ::prost::alloc::vec::Vec<TransportNote>,
+    /// Transport Layer pagination
+    #[prost(fixed64, tag = "2")]
+    pub cursor: u64,
 }
 /// Server statistics
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/database/sqlite/mod.rs
+++ b/crates/rust-client/src/database/sqlite/mod.rs
@@ -73,7 +73,8 @@ impl SqliteDatabase {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(feature = "idxdb"), async_trait::async_trait)]
+#[cfg_attr(feature = "idxdb", async_trait::async_trait(?Send))]
 impl DatabaseBackend for SqliteDatabase {
     async fn store_note(
         &self,

--- a/crates/rust-client/tests/test_transport_client_state.rs
+++ b/crates/rust-client/tests/test_transport_client_state.rs
@@ -27,7 +27,7 @@ async fn test_transport_client_note_fetch_tracking()
     // Initially, the note should not be marked as fetched
     assert!(!client1.note_fetched(&note_id).await.unwrap());
 
-    let _notes = client1.fetch_notes(tag).await?;
+    let _notes = client1.fetch_notes(&[tag]).await?;
     assert!(client1.note_fetched(&note_id).await.unwrap());
 
     handle.abort();
@@ -50,7 +50,7 @@ async fn test_transport_client_note_storage() -> std::result::Result<(), Box<dyn
 
     // Fetch
     let sent_tag = adr1.to_note_tag();
-    let fetched_notes = client1.fetch_notes(sent_tag).await.unwrap();
+    let fetched_notes = client1.fetch_notes(&[sent_tag]).await.unwrap();
     assert_eq!(fetched_notes.len(), 1);
 
     // Verify marked as fetched in the DB

--- a/crates/web-client/app/simple-app.html
+++ b/crates/web-client/app/simple-app.html
@@ -172,8 +172,8 @@
     <div class="container">
         <h2>📥 Fetch Notes</h2>
         <div class="form-group">
-            <label for="noteTag">Note Tag (integer):</label>
-            <input type="number" id="noteTag" placeholder="Enter note tag as integer (e.g., 123)" min="0">
+            <label for="noteTags">Note Tags (comma-separated integers):</label>
+            <input type="text" id="noteTags" placeholder="Enter note tags as comma-separated integers (e.g., 123 or 123,456,789)">
         </div>
         <button id="fetchNotesBtn" onclick="fetchNotes()" disabled>Fetch Notes</button>
         <div id="fetchStatus" class="status info" style="display: none;"></div>
@@ -338,34 +338,38 @@
                 return;
             }
 
-            const noteTagValue = document.getElementById('noteTag').value;
+            const noteTagsValue = document.getElementById('noteTags').value;
 
-            if (!noteTagValue) {
-                showStatus('fetchStatus', 'Please enter a note tag', 'error');
+            if (!noteTagsValue) {
+                showStatus('fetchStatus', 'Please enter note tags', 'error');
                 return;
             }
 
             try {
-                showStatus('fetchStatus', 'Parsing tag...', 'info');
+                showStatus('fetchStatus', 'Parsing tags...', 'info');
                 
-                // Parse the integer tag
-                const tagInt = parseInt(noteTagValue, 10);
-                if (isNaN(tagInt)) {
-                    throw new Error('Note tag must be a valid integer');
-                }
+                // Parse the comma-separated integer tags
+                const tagStrings = noteTagsValue.split(',').map(s => s.trim());
+                const tagInts = tagStrings.map(s => {
+                    const parsed = parseInt(s, 10);
+                    if (isNaN(parsed)) {
+                        throw new Error(`Invalid tag: "${s}" must be a valid integer`);
+                    }
+                    return parsed;
+                });
                 
-                const noteTag = create_note_tag_from_int(tagInt);
+                const noteTags = tagInts.map(tagInt => create_note_tag_from_int(tagInt));
                 
                 showStatus('fetchStatus', 'Fetching notes...', 'info');
-                const notes = await client.fetchNotes(noteTag);
+                const notes = await client.fetchNotes(noteTags);
                 
                 showStatus('fetchStatus', `✅ Fetched ${notes.length} notes successfully!`, 'success');
                 
                 // Display meaningful note information
-                let output = `Found ${notes.length} notes with tag ${tagInt}.\n\n`;
+                let output = `Found ${notes.length} notes with tags [${tagInts.join(', ')}].\n\n`;
                 
                 if (notes.length === 0) {
-                    output += 'No notes found with this tag.';
+                    output += 'No notes found with these tags.';
                 } else {
                     for (let i = 0; i < notes.length; i++) {
                         const note = notes[i];
@@ -391,6 +395,7 @@
                 showOutput('fetchOutput', `Error details: ${error.stack}`);
             }
         };
+
 
         // Initialize UI
         updateConnectionUI();

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -71,14 +71,14 @@ export class TransportLayerWebClient {
   /**
    * Fetch notes from the transport layer
    *
-   * @param {NoteTag} tag - The note tag to filter by
+   * @param {Array<NoteTag>} tags - Array of note tags to filter by (can be single tag in array)
    * @returns {Promise<Array<Note>>} Array of note objects
    */
-  async fetchNotes(tag) {
+  async fetchNotes(tags) {
     if (!this.wasmClient) {
       throw new Error("Client not initialized. Call connect() first.");
     }
-    return await this.wasmClient.fetchNotes(tag);
+    return await this.wasmClient.fetchNotes(tags);
   }
 
   /**

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -62,18 +62,18 @@ impl TransportLayerWebClient {
         Ok(note_id.into())
     }
 
-    /// Fetch notes from the transport layer
+    /// Fetch notes from the transport layer for one or more tags
     #[wasm_bindgen(js_name = "fetchNotes")]
-    pub async fn fetch_notes(&mut self, tag: &NoteTag) -> Result<Vec<Note>, JsValue> {
+    pub async fn fetch_notes(&mut self, tags: Vec<NoteTag>) -> Result<Vec<Note>, JsValue> {
         let inner = self
             .inner
             .as_mut()
             .ok_or_else(|| JsValue::from_str("Client not initialized. Call connect() first."))?;
 
-        let native_tag: NativeNoteTag = tag.into();
+        let native_tags: Vec<NativeNoteTag> = tags.iter().map(|tag| tag.into()).collect();
 
         let notes = inner
-            .fetch_notes(native_tag)
+            .fetch_notes(&native_tags)
             .await
             .map_err(|e| JsValue::from_str(&format!("Failed to fetch notes: {e:?}")))?;
 

--- a/crates/web-client/test/transport.test.ts
+++ b/crates/web-client/test/transport.test.ts
@@ -93,9 +93,9 @@ test.describe("Transport Layer Tests", () => {
         // Send note first
         await client.sendNote(note, target);
         
-        // Fetch notes by target's tag
+        // Fetch notes by target's tag (single tag in array)
         const targetTag = target.toNoteTag();
-        const fetchedNotes = await client.fetchNotes(targetTag);
+        const fetchedNotes = await client.fetchNotes([targetTag]);
         
         return { 
           success: true, 


### PR DESCRIPTION
Change note fetching to (single cursor, multiple tags) request.
Streaming not updated since it changes the internal of the service a bit. Nevertheless the client can still subscribe to different tags using different streams.