### PR TITLE
feat: Pagination limit on fetch-notes

### DIFF
--- a/crates/node/src/database/maintenance.rs
+++ b/crates/node/src/database/maintenance.rs
@@ -62,6 +62,8 @@ impl DatabaseMaintenance {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use miden_objects::account::AccountId;
+    use miden_objects::testing::account_id::ACCOUNT_ID_MAX_ZEROES;
     use serial_test::serial;
 
     use super::*;
@@ -69,9 +71,13 @@ mod tests {
     use crate::test_utils::test_note_header;
     use crate::types::StoredNote;
 
+    fn default_test_account_id() -> AccountId {
+        AccountId::try_from(ACCOUNT_ID_MAX_ZEROES).unwrap()
+    }
+
     fn note_at(age: Duration) -> StoredNote {
         StoredNote {
-            header: test_note_header(),
+            header: test_note_header(default_test_account_id()),
             details: vec![1, 2, 3, 4],
             created_at: Utc::now() - age,
         }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -167,13 +167,14 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
         let request_data = request.into_inner();
         let tags = request_data.tags.into_iter().collect::<BTreeSet<_>>();
         let cursor = request_data.cursor;
+        let limit = request_data.limit;
 
         let mut rcursor = cursor;
         let mut proto_notes = vec![];
         for tag in tags {
             let stored_notes = self
                 .database
-                .fetch_notes(tag.into(), cursor)
+                .fetch_notes(tag.into(), cursor, limit)
                 .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
             for stored_note in &stored_notes {

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -1,6 +1,5 @@
 mod streaming;
 
-use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -165,29 +164,27 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
         let timer = self.metrics.grpc_fetch_notes_request();
 
         let request_data = request.into_inner();
-        let tags = request_data.tags.into_iter().collect::<BTreeSet<_>>();
+        let tags: Vec<_> = request_data.tags.into_iter().map(std::convert::Into::into).collect();
         let cursor = request_data.cursor;
         let limit = request_data.limit;
 
+        let stored_notes = self
+            .database
+            .fetch_notes(&tags, cursor, limit)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
+
         let mut rcursor = cursor;
-        let mut proto_notes = vec![];
-        for tag in tags {
-            let stored_notes = self
-                .database
-                .fetch_notes(tag.into(), cursor, limit)
-                .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
-
-            for stored_note in &stored_notes {
-                let ts_cursor: u64 = stored_note
-                    .created_at
-                    .timestamp_micros()
-                    .try_into()
-                    .map_err(|_| tonic::Status::internal("Timestamp too large for cursor"))?;
-                rcursor = rcursor.max(ts_cursor);
-            }
-
-            proto_notes.extend(stored_notes.into_iter().map(TransportNote::from));
+        for stored_note in &stored_notes {
+            let ts_cursor: u64 = stored_note
+                .created_at
+                .timestamp_micros()
+                .try_into()
+                .map_err(|_| tonic::Status::internal("Timestamp too large for cursor"))?;
+            rcursor = rcursor.max(ts_cursor);
         }
+
+        let proto_notes: Vec<_> = stored_notes.into_iter().map(TransportNote::from).collect();
 
         timer.finish("ok");
 

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -79,7 +79,7 @@ impl NoteStreamerManager {
 
         let mut updates = vec![];
         for (tag, tag_data) in &self.tags {
-            let snotes = self.database.fetch_notes(*tag, tag_data.lts, None).await?;
+            let snotes = self.database.fetch_notes(&[*tag], tag_data.lts, None).await?;
             let mut cursor = tag_data.lts;
             for snote in &snotes {
                 let lcursor = snote

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -79,7 +79,7 @@ impl NoteStreamerManager {
 
         let mut updates = vec![];
         for (tag, tag_data) in &self.tags {
-            let snotes = self.database.fetch_notes(*tag, tag_data.lts).await?;
+            let snotes = self.database.fetch_notes(*tag, tag_data.lts, None).await?;
             let mut cursor = tag_data.lts;
             for snote in &snotes {
                 let lcursor = snote

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -1,4 +1,4 @@
-use miden_objects::account::AccountId;
+use miden_objects::account::{AccountId, AccountStorageMode};
 use miden_objects::note::{NoteExecutionHint, NoteHeader, NoteId, NoteMetadata, NoteTag, NoteType};
 use miden_objects::testing::account_id::{ACCOUNT_ID_MAX_ZEROES, AccountIdBuilder};
 use miden_objects::{Felt, Word};
@@ -6,7 +6,9 @@ use rand::Rng;
 
 /// Generate a random [`AccountId`]
 pub fn random_account_id() -> AccountId {
-    AccountIdBuilder::new().build_with_rng(&mut rand::rng())
+    AccountIdBuilder::new()
+        .storage_mode(AccountStorageMode::Private)
+        .build_with_rng(&mut rand::rng())
 }
 
 /// Generate a random [`NoteId`]

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -1,8 +1,13 @@
 use miden_objects::account::AccountId;
 use miden_objects::note::{NoteExecutionHint, NoteHeader, NoteId, NoteMetadata, NoteTag, NoteType};
-use miden_objects::testing::account_id::ACCOUNT_ID_MAX_ZEROES;
+use miden_objects::testing::account_id::{ACCOUNT_ID_MAX_ZEROES, AccountIdBuilder};
 use miden_objects::{Felt, Word};
 use rand::Rng;
+
+/// Generate a random [`AccountId`]
+pub fn random_account_id() -> AccountId {
+    AccountIdBuilder::new().build_with_rng(&mut rand::rng())
+}
 
 /// Generate a random [`NoteId`]
 pub fn random_note_id() -> NoteId {
@@ -24,12 +29,15 @@ pub fn random_note_id() -> NoteId {
     NoteId::new(recipient, asset_commitment)
 }
 
-/// Generate a private [`NoteHeader`] with random sender
-pub fn test_note_header() -> NoteHeader {
+/// Generate a private [`NoteHeader`] with the tag derived from the given recipient account ID.
+///
+/// The tag is created using [`NoteTag::from_account_id`] with the provided `recipient` account ID.
+/// This allows tests to create notes with different tags by passing different account IDs.
+pub fn test_note_header(recipient: AccountId) -> NoteHeader {
     let id = random_note_id();
     let sender = AccountId::try_from(ACCOUNT_ID_MAX_ZEROES).unwrap();
     let note_type = NoteType::Private;
-    let tag = NoteTag::from_account_id(sender);
+    let tag = NoteTag::from_account_id(recipient);
     let aux = Felt::try_from(0xffff_ffff_0000_0000u64).unwrap();
     let execution_hint = NoteExecutionHint::None;
 

--- a/crates/proto/src/generated/miden_note_transport.rs
+++ b/crates/proto/src/generated/miden_note_transport.rs
@@ -26,6 +26,8 @@ pub struct FetchNotesRequest {
     pub tags: ::prost::alloc::vec::Vec<u32>,
     #[prost(fixed64, tag = "2")]
     pub cursor: u64,
+    #[prost(fixed32, optional, tag = "3")]
+    pub limit: ::core::option::Option<u32>,
 }
 /// API response for fetching notes
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/proto/miden_note_transport.proto
+++ b/proto/proto/miden_note_transport.proto
@@ -26,6 +26,7 @@ message SendNoteResponse { }
 message FetchNotesRequest {
     repeated fixed32 tags = 1;
     fixed64 cursor = 2;
+    optional fixed32 limit = 3;
 }
 
 // API response for fetching notes


### PR DESCRIPTION
Supports now a limit on the number of fetched notes.
Since the client tracks only a single global cursor for all tags, the DB now supports settings multiple tags at once, and that limit is applied on the joint set of notes with the multiple tags, ordered by timestamp/cursor.

Some (mock) client tests should be added on top of #54 code.