### PR TITLE
feat: rate limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,22 +77,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,9 +147,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -200,7 +200,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -226,15 +226,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "beef"
@@ -244,9 +244,9 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560f42649de9fa436b73517378a147ec21f6c997a546581df4b4b31677828934"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
@@ -300,21 +300,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -363,7 +363,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -571,6 +571,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,29 +646,30 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn",
 ]
 
 [[package]]
 name = "diesel"
-version = "2.3.3"
+version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7624a3bb9fffd82fff016be9a7f163d20e5a89eb8d28f9daaa6b30fff37500"
+checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
 dependencies = [
  "bigdecimal",
  "diesel_derives",
@@ -669,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.3.4"
+version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9daac6489a36e42570da165a10c424f3edcefdff70c5fd55e1847c23f3dd7562"
+checksum = "c30b2969f923fa1f73744b92bb7df60b858df8832742d9a3aceb79236c0be1d2"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -682,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee060f709c3e3b1cadd83fcd0f61711f7a8cf493348f758d3a1c1147d70b3c97"
+checksum = "745fd255645f0f1135f9ec55c7b00e0882192af9683ab4731e4bba3da82b8f9c"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -859,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -886,9 +901,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "fixedbitset"
@@ -915,10 +930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs-err"
-version = "3.1.3"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad492b2cf1d89d568a43508ab24f98501fe03f2f31c01e1d0fe7366a71745d2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fs-err"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
 dependencies = [
  "autocfg",
 ]
@@ -995,6 +1016,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,23 +1041,24 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1077,6 +1105,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,9 +1159,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1144,12 +1204,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1190,9 +1249,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1226,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1257,7 +1316,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1283,12 +1342,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1323,15 +1382,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
 dependencies = [
  "jiff-static",
  "log",
@@ -1342,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1432,9 +1491,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libm"
@@ -1475,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logos"
@@ -1549,9 +1608,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden-air"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cfe0ccecbd2e7a8a2cd97544d4cef438cb495e84e1a5769371dc822ff67268"
+checksum = "06acfd2ddc25b68f9d23d2add3f15c0ec3f9890ce6418409d71bea9dc6590bd0"
 dependencies = [
  "miden-core",
  "miden-utils-indexing",
@@ -1562,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95978901bbe5cfc5632a85776d122ae3376a0728e5a4b4211c478d0a87c9e715"
+checksum = "d1219b9e48bb286b58a23bb65cf74baa1b24ddbcb462ca625b38186674571047"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1576,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e4ae33c9801102e32e04d51917333b0576d245e996f5ff43b0e2820f156876"
+checksum = "1eeaef2853061c54527bb2664c0c832ce3d1f80847c79512455fec3b93057f2a"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1598,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a8fd613e996b6d818a973ca40c484787848f14bea0a0c7aa1158ba9b26c2"
+checksum = "452a00429d05c416001ec0578291eb88e115cf94fc22b3308267abfdcd813440"
 dependencies = [
  "enum_dispatch",
  "miden-crypto",
@@ -1616,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.18.1"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd4233803234f287596d9a60c67c4e5762f792eb0dd20969a41c8db093d6126"
+checksum = "395e5cc76b64e24533ee55c8d1ff90305b8cad372bdbea4f4f324239e36a895f"
 dependencies = [
  "blake3",
  "cc",
@@ -1646,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.18.1"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70dccd82a2b2787b9bfc64687cd224dfe0adc0d21ae9b241b0c6edc4a23335"
+checksum = "c89641b257eb395cf03105ac1c6cbdf3fd9a5450749696af9835c3c47fc6806e"
 dependencies = [
  "quote",
  "syn",
@@ -1656,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b37453feb8f4392af5eef29a11ac099b76cbcc47ffc034944a573d06a1cc1e"
+checksum = "97eed62ac0ca7420e49148fd306c74786b23a8d31df6da6277c671ba3e5c619a"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1683,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb106cd425958cb2f6fab03741d4d8905b31dca48c0942dfd61adfe6970c695f"
+checksum = "1d13e6ba2b357551598f13396ed52f8f21aa99979aa3b338bb5521feeda19c8a"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1747,6 +1806,9 @@ dependencies = [
  "deadpool-sync",
  "diesel",
  "diesel_migrations",
+ "futures",
+ "governor",
+ "http",
  "miden-note-transport-proto",
  "miden-objects",
  "opentelemetry",
@@ -1826,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97fbbc6911627d1fd25ad6f598a7ccd79721e9c89c4890a105f0a906ea3baf7"
+checksum = "d2ef77929651b8755965cde8f589bd38e2345a619d54cab6427f91aa23c47f6a"
 dependencies = [
  "itertools",
  "miden-air",
@@ -1862,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d2d3d0909fa09ba58c6965f0dfafefeb299822dc417893786c119211cac89c"
+checksum = "1a3ff4c019d96539a7066626efb4dce5c9fb7b0e44e961b0c2571e78f34236d5"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1875,18 +1937,18 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f35669a21d99c0d5f96720ba80205438f5e63a4132dfa4d1089bc95efce7760"
+checksum = "c798250bee4e856d4f18c161e91cdcbef1906f6614d00cf0063b47031c0f8cc6"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9f2e82680ceff6618373c61d5947eda6eaf95f3503cf8310d3fb12a1dbdf9f"
+checksum = "feebe7d896c013ea74dbc98de978836606356a044d4ed3b61ded54d3b319d89f"
 dependencies = [
  "lock_api",
  "loom",
@@ -1895,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e25b94000d5eaa24375c1c0a6fb49e1f349a35b59f51717359f06bc56fe14f"
+checksum = "b8f8e47b78bba1fe1b31faee8f12aafd95385f6d6a8b108b03e92f5d743bb29f"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1908,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7798671ffbf6596de00619a9abaec67dc26965b891328c9d65c4cb6007597d50"
+checksum = "9d4cfab04baffdda3fb9eafa5f873604059b89a1699aa95e4f1057397a69f0b5"
 dependencies = [
  "miden-formatting",
  "smallvec",
@@ -1977,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -2006,6 +2068,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2146,9 +2220,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "opentelemetry"
@@ -2236,7 +2310,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2331,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2377,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2469,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a3ac73ec9a9118131a4594c9d336631a07852220a1d0ae03ee36b04503a063"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
  "logos",
  "miette",
@@ -2490,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "protox"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8555716f64c546306ddf3383065dc40d4232609e79e0a4c50e94e87d54f30fb4"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
 dependencies = [
  "bytes",
  "miette",
@@ -2528,18 +2602,33 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "21.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
+checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.41"
+name = "quanta"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2613,6 +2702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2731,20 +2829,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2764,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2776,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -2799,12 +2897,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2945,22 +3037,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -3080,6 +3172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,17 +3192,15 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e4348c16a3d2e2a45437eff67efc5462b60443de76f61b5d0ed9111c626d9d"
+checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
 dependencies = [
+ "cc",
+ "hashbrown 0.16.1",
  "js-sys",
- "once_cell",
  "thiserror",
- "tokio",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -3148,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "supports-hyperlinks"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
 
 [[package]]
 name = "supports-unicode"
@@ -3160,9 +3259,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3183,22 +3282,22 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3356,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3371,27 +3470,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -3541,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3567,9 +3666,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3578,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3589,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3638,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3665,9 +3764,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559b6a626c0815c942ac98d434746138b4f89ddd6a1b8cbb168c6845fb3376c5"
+checksum = "3e17e807bff86d2a06b52bca4276746584a78375055b6e45843925ce2802b335"
 dependencies = [
  "dissimilar",
  "glob",
@@ -3812,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3824,23 +3923,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3848,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3861,18 +3947,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3889,48 +3975,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3940,20 +4013,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3980,34 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-result"
@@ -4015,16 +4052,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4033,7 +4061,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4056,6 +4084,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -4069,7 +4106,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4109,7 +4146,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4118,15 +4155,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4269,9 +4297,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "winter-air"
@@ -4390,18 +4418,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4413,3 +4441,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3280a1b827474fcd5dbef4b35a674deb52ba5c312363aef9135317df179d81b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ deadpool = { default-features = false, features = ["managed", "rt_tokio_1"], ver
 deadpool-sync = { version = "0.1" }
 fs-err = { version = "3" }
 futures = { version = "0.3" }
+governor = { version = "0.8" }
+http = { version = "1" }
 miette = { version = "7.6" }
 opentelemetry = { version = "0.30" }
 opentelemetry-otlp = { default-features = false, features = [

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use clap::Parser;
 use miden_note_transport_node::database::DatabaseConfig;
 use miden_note_transport_node::logging::{TracingConfig, setup_tracing};
@@ -38,13 +40,18 @@ struct Args {
     request_timeout: usize,
 
     // Rate limiting settings
-    /// Rate limit: requests per second per IP
+    /// Rate limit: sustained requests per second per IP
     #[arg(long, default_value = "50")]
-    rate_limit_rps: u32,
+    rate_limit_rps: NonZeroU32,
 
-    /// Rate limit: burst size (allows temporary spikes)
+    /// Rate limit: burst size (max tokens in the bucket)
     #[arg(long, default_value = "100")]
-    rate_limit_burst: u32,
+    rate_limit_burst: NonZeroU32,
+
+    /// Trust `X-Forwarded-For` / `X-Real-IP` headers when identifying the client.
+    /// Only enable when the server sits behind a trusted reverse proxy.
+    #[arg(long, default_value_t = false)]
+    rate_limit_trust_forwarded_headers: bool,
 
     // TCP settings
     /// TCP keepalive interval in seconds (0 to disable)
@@ -67,16 +74,22 @@ async fn main() -> Result<()> {
     info!("Database: {}", args.database_url);
     info!("Max note size: {} bytes", args.max_note_size);
     info!("Retention days: {}", args.retention_days);
-    info!("Rate limit: {} req/s, burst: {}", args.rate_limit_rps, args.rate_limit_burst);
-    info!("TCP keepalive: {}s", args.tcp_keepalive);
+    info!(
+        "Rate limit: {} req/s, burst: {}, trust forwarded headers: {}",
+        args.rate_limit_rps, args.rate_limit_burst, args.rate_limit_trust_forwarded_headers,
+    );
+    if args.tcp_keepalive == 0 {
+        info!("TCP keepalive: disabled");
+    } else {
+        info!("TCP keepalive: {}s", args.tcp_keepalive);
+    }
     info!(
         "Telemetry: OpenTelemetry={}, JSON={}",
         tracing_cfg.otel.is_enabled(),
         tracing_cfg.json_format
     );
 
-    // Helper to convert 0 to None for optional duration settings
-    let opt_nonzero = |v: u64| if v == 0 { None } else { Some(v) };
+    let tcp_keepalive_secs = (args.tcp_keepalive != 0).then_some(args.tcp_keepalive);
 
     // Create Node config
     let config = NodeConfig {
@@ -89,8 +102,9 @@ async fn main() -> Result<()> {
             rate_limit: RateLimitConfig {
                 requests_per_second: args.rate_limit_rps,
                 burst_size: args.rate_limit_burst,
+                trust_forwarded_headers: args.rate_limit_trust_forwarded_headers,
             },
-            tcp_keepalive_secs: opt_nonzero(args.tcp_keepalive),
+            tcp_keepalive_secs,
         },
         database: DatabaseConfig {
             url: args.database_url,

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use miden_note_transport_node::database::DatabaseConfig;
 use miden_note_transport_node::logging::{TracingConfig, setup_tracing};
-use miden_note_transport_node::node::grpc::GrpcServerConfig;
+use miden_note_transport_node::node::grpc::{GrpcServerConfig, RateLimitConfig};
 use miden_note_transport_node::{Node, NodeConfig, Result};
 use tracing::info;
 
@@ -36,6 +36,20 @@ struct Args {
     /// Connection timeout in seconds
     #[arg(long, default_value = "4")]
     request_timeout: usize,
+
+    // Rate limiting settings
+    /// Rate limit: requests per second per IP
+    #[arg(long, default_value = "50")]
+    rate_limit_rps: u32,
+
+    /// Rate limit: burst size (allows temporary spikes)
+    #[arg(long, default_value = "100")]
+    rate_limit_burst: u32,
+
+    // TCP settings
+    /// TCP keepalive interval in seconds (0 to disable)
+    #[arg(long, default_value = "60")]
+    tcp_keepalive: u64,
 }
 
 #[tokio::main]
@@ -53,11 +67,16 @@ async fn main() -> Result<()> {
     info!("Database: {}", args.database_url);
     info!("Max note size: {} bytes", args.max_note_size);
     info!("Retention days: {}", args.retention_days);
+    info!("Rate limit: {} req/s, burst: {}", args.rate_limit_rps, args.rate_limit_burst);
+    info!("TCP keepalive: {}s", args.tcp_keepalive);
     info!(
         "Telemetry: OpenTelemetry={}, JSON={}",
         tracing_cfg.otel.is_enabled(),
         tracing_cfg.json_format
     );
+
+    // Helper to convert 0 to None for optional duration settings
+    let opt_nonzero = |v: u64| if v == 0 { None } else { Some(v) };
 
     // Create Node config
     let config = NodeConfig {
@@ -67,6 +86,11 @@ async fn main() -> Result<()> {
             max_note_size: args.max_note_size,
             max_connections: args.max_connections,
             request_timeout: args.request_timeout,
+            rate_limit: RateLimitConfig {
+                requests_per_second: args.rate_limit_rps,
+                burst_size: args.rate_limit_burst,
+            },
+            tcp_keepalive_secs: opt_nonzero(args.tcp_keepalive),
         },
         database: DatabaseConfig {
             url: args.database_url,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -64,7 +64,14 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 
 # General
-rand = { workspace = true }
+futures = { workspace = true }
+rand    = { workspace = true }
+
+# Rate limiting
+governor = { version = "0.8" }
+
+# HTTP types
+http = { version = "1" }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -68,10 +68,10 @@ futures = { workspace = true }
 rand    = { workspace = true }
 
 # Rate limiting
-governor = { version = "0.8" }
+governor = { workspace = true }
 
 # HTTP types
-http = { version = "1" }
+http = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -1,3 +1,4 @@
+mod rate_limit;
 mod streaming;
 
 use std::collections::BTreeSet;
@@ -25,6 +26,7 @@ use tower::limit::GlobalConcurrencyLimitLayer;
 use tower::timeout::TimeoutLayer;
 use tower_http::cors::{Any, CorsLayer};
 
+pub use self::rate_limit::RateLimitConfig;
 use self::streaming::{NoteStreamer, StreamerMessage, Sub, Subface};
 use crate::database::Database;
 use crate::metrics::MetricsGrpc;
@@ -50,6 +52,10 @@ pub struct GrpcServerConfig {
     pub max_connections: usize,
     /// Connection timeout in seconds
     pub request_timeout: usize,
+    /// Rate limiting configuration
+    pub rate_limit: RateLimitConfig,
+    /// TCP keepalive interval in seconds (None to disable)
+    pub tcp_keepalive_secs: Option<u64>,
 }
 
 /// Streaming task interface context
@@ -66,6 +72,8 @@ impl Default for GrpcServerConfig {
             max_note_size: 512_000,
             max_connections: 4096,
             request_timeout: 4,
+            rate_limit: RateLimitConfig::default(),
+            tcp_keepalive_secs: Some(60),
         }
     }
 }
@@ -92,11 +100,22 @@ impl GrpcServer {
             .map_err(|e| crate::Error::Internal(format!("Invalid address: {e}")))?;
 
         let cors = CorsLayer::new().allow_origin(Any).allow_headers(Any).allow_methods(Any);
+        let rate_limit_layer = rate_limit::RateLimitLayer::new(&self.config.rate_limit);
 
-        tonic::transport::Server::builder()
+        let mut builder = tonic::transport::Server::builder()
             .accept_http1(true)
+            // TCP settings
+            .tcp_nodelay(true);
+
+        // TCP keepalive
+        if let Some(keepalive_secs) = self.config.tcp_keepalive_secs {
+            builder = builder.tcp_keepalive(Some(Duration::from_secs(keepalive_secs)));
+        }
+
+        builder
             .layer(cors)
             .layer(GrpcWebLayer::new())
+            .layer(rate_limit_layer)
             .layer(GlobalConcurrencyLimitLayer::new(self.config.max_connections))
             .layer(TimeoutLayer::new(Duration::from_secs(self.config.request_timeout as u64)))
             .add_service(health_svc)

--- a/crates/node/src/node/grpc/rate_limit.rs
+++ b/crates/node/src/node/grpc/rate_limit.rs
@@ -1,0 +1,145 @@
+use std::net::IpAddr;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use governor::clock::{DefaultClock, QuantaInstant};
+use governor::middleware::NoOpMiddleware;
+use governor::state::keyed::DashMapStateStore;
+use governor::{Quota, RateLimiter};
+use http::{Request, Response, StatusCode};
+use tonic::body::Body as TonicBody;
+use tower::{Layer, Service};
+
+/// Rate limiter type
+pub type IpRateLimiter =
+    RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock, NoOpMiddleware<QuantaInstant>>;
+
+/// Configuration for rate limiting
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    /// Maximum requests per second per IP
+    pub requests_per_second: u32,
+    /// Allow temporary spikes
+    pub burst_size: u32,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self { requests_per_second: 50, burst_size: 100 }
+    }
+}
+
+/// Tower layer for per-IP rate limiting
+#[derive(Clone)]
+pub struct RateLimitLayer {
+    limiter: Arc<IpRateLimiter>,
+}
+
+impl RateLimitLayer {
+    /// Create a new rate limit layer from config
+    pub fn new(config: &RateLimitConfig) -> Self {
+        let quota = Quota::per_second(
+            NonZeroU32::new(config.requests_per_second).unwrap_or(NonZeroU32::MIN),
+        )
+        .allow_burst(NonZeroU32::new(config.burst_size).unwrap_or(NonZeroU32::MIN));
+
+        Self {
+            limiter: Arc::new(RateLimiter::dashmap(quota)),
+        }
+    }
+}
+
+impl<S> Layer<S> for RateLimitLayer {
+    type Service = RateLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimitService { inner, limiter: self.limiter.clone() }
+    }
+}
+
+/// Rate limiting service that wraps an inner service
+#[derive(Clone)]
+pub struct RateLimitService<S> {
+    inner: S,
+    limiter: Arc<IpRateLimiter>,
+}
+
+impl<S> RateLimitService<S> {
+    /// Extract client IP from request
+    ///
+    /// Checks headers in order:
+    /// 1. `x-forwarded-for` (first IP in the chain, from reverse proxy)
+    /// 2. `x-real-ip` (common alternative header)
+    /// 3. Connected peer address (direct connection)
+    /// 4. Fallback to localhost
+    fn extract_ip<B>(req: &Request<B>) -> IpAddr {
+        // Try X-Forwarded-For header first (for reverse proxy setups)
+        if let Some(forwarded_for) = req.headers().get("x-forwarded-for") {
+            if let Ok(header_str) = forwarded_for.to_str() {
+                // Take the first IP in the chain (original client)
+                if let Some(first_ip) = header_str.split(',').next() {
+                    if let Ok(ip) = first_ip.trim().parse::<IpAddr>() {
+                        return ip;
+                    }
+                }
+            }
+        }
+
+        // Try X-Real-IP header
+        if let Some(real_ip) = req.headers().get("x-real-ip") {
+            if let Ok(header_str) = real_ip.to_str() {
+                if let Ok(ip) = header_str.trim().parse::<IpAddr>() {
+                    return ip;
+                }
+            }
+        }
+
+        // Fall back to connected peer address from extensions
+        if let Some(addr) = req.extensions().get::<tonic::transport::server::TcpConnectInfo>() {
+            if let Some(remote_addr) = addr.remote_addr() {
+                return remote_addr.ip();
+            }
+        }
+
+        // Last resort: use localhost
+        // Ensures we don't fail the request, but rate limits unknown sources together
+        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+    }
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for RateLimitService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<TonicBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future =
+        futures::future::Either<S::Future, std::future::Ready<Result<Self::Response, Self::Error>>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let ip = Self::extract_ip(&req);
+
+        // Check rate limit
+        if self.limiter.check_key(&ip).is_err() {
+            // return 429
+            let response = Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header("content-type", "application/grpc")
+                .header("grpc-status", "14") // unavailable
+                .header("grpc-message", "rate limit exceeded")
+                .body(TonicBody::empty())
+                .unwrap();
+
+            return futures::future::Either::Right(std::future::ready(Ok(response)));
+        }
+
+        futures::future::Either::Left(self.inner.call(req))
+    }
+}

--- a/crates/node/src/node/grpc/rate_limit.rs
+++ b/crates/node/src/node/grpc/rate_limit.rs
@@ -18,7 +18,14 @@ pub type IpRateLimiter =
     RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock, NoOpMiddleware<QuantaInstant>>;
 
 /// How often idle-IP entries are purged from the state store.
-const RETAIN_INTERVAL: Duration = Duration::from_secs(60);
+const RETAIN_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Sentinel bucket for requests whose client IP cannot be determined. In
+/// practice the tonic transport always attaches `TcpConnectInfo`, so this
+/// branch should never fire in production — but rather than let unidentified
+/// traffic bypass the limiter, we key all such requests to a single shared
+/// bucket and rate-limit them together.
+const UNKNOWN_IP_BUCKET: IpAddr = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
 
 /// Configuration for rate limiting.
 #[derive(Debug, Clone)]
@@ -100,23 +107,23 @@ pub struct RateLimitService<S> {
 }
 
 impl<S> RateLimitService<S> {
-    /// Client IP used for rate-limit bucketing, or `None` if it cannot be
-    /// determined (in which case the request is allowed through — we prefer
-    /// that over lumping unrelated requests into a shared bucket).
-    fn extract_ip<B>(&self, req: &Request<B>) -> Option<IpAddr> {
+    /// Client IP used for rate-limit bucketing. Falls back to
+    /// [`UNKNOWN_IP_BUCKET`] when the IP cannot be determined, so
+    /// unidentified traffic is still rate-limited (shared bucket).
+    fn extract_ip<B>(&self, req: &Request<B>) -> IpAddr {
         if self.trust_forwarded_headers {
             if let Some(ip) = req.headers().get("x-forwarded-for").and_then(parse_forwarded_for) {
-                return Some(ip);
+                return ip;
             }
             if let Some(ip) = req.headers().get("x-real-ip").and_then(parse_single_ip) {
-                return Some(ip);
+                return ip;
             }
         }
 
         req.extensions()
             .get::<tonic::transport::server::TcpConnectInfo>()
             .and_then(tonic::transport::server::TcpConnectInfo::remote_addr)
-            .map(|addr| addr.ip())
+            .map_or(UNKNOWN_IP_BUCKET, |addr| addr.ip())
     }
 }
 
@@ -171,12 +178,11 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        if let Some(ip) = self.extract_ip(&req) {
-            if self.limiter.check_key(&bucket(ip)).is_err() {
-                return futures::future::Either::Right(std::future::ready(Ok(
-                    rate_limit_exceeded_response(),
-                )));
-            }
+        let key = bucket(self.extract_ip(&req));
+        if self.limiter.check_key(&key).is_err() {
+            return futures::future::Either::Right(std::future::ready(Ok(
+                rate_limit_exceeded_response(),
+            )));
         }
 
         futures::future::Either::Left(self.inner.call(req))
@@ -209,28 +215,28 @@ mod tests {
     async fn extract_ip_honors_forwarded_for_when_trusted() {
         let svc = service(true);
         let req = req_with_headers(&[("x-forwarded-for", "203.0.113.1, 10.0.0.1")]);
-        assert_eq!(svc.extract_ip(&req), Some("203.0.113.1".parse().unwrap()));
+        assert_eq!(svc.extract_ip(&req), "203.0.113.1".parse::<IpAddr>().unwrap());
     }
 
     #[tokio::test]
     async fn extract_ip_ignores_forwarded_for_when_untrusted() {
         let svc = service(false);
         let req = req_with_headers(&[("x-forwarded-for", "203.0.113.1")]);
-        assert_eq!(svc.extract_ip(&req), None);
+        assert_eq!(svc.extract_ip(&req), UNKNOWN_IP_BUCKET);
     }
 
     #[tokio::test]
     async fn extract_ip_falls_back_to_real_ip_when_trusted() {
         let svc = service(true);
         let req = req_with_headers(&[("x-real-ip", "198.51.100.7")]);
-        assert_eq!(svc.extract_ip(&req), Some("198.51.100.7".parse().unwrap()));
+        assert_eq!(svc.extract_ip(&req), "198.51.100.7".parse::<IpAddr>().unwrap());
     }
 
     #[tokio::test]
-    async fn extract_ip_ignores_malformed_forwarded_for() {
+    async fn extract_ip_falls_back_to_unknown_bucket_on_malformed_forwarded_for() {
         let svc = service(true);
         let req = req_with_headers(&[("x-forwarded-for", "not-an-ip")]);
-        assert_eq!(svc.extract_ip(&req), None);
+        assert_eq!(svc.extract_ip(&req), UNKNOWN_IP_BUCKET);
     }
 
     #[test]

--- a/crates/node/src/node/grpc/rate_limit.rs
+++ b/crates/node/src/node/grpc/rate_limit.rs
@@ -1,51 +1,80 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use governor::clock::{DefaultClock, QuantaInstant};
 use governor::middleware::NoOpMiddleware;
 use governor::state::keyed::DashMapStateStore;
 use governor::{Quota, RateLimiter};
-use http::{Request, Response, StatusCode};
+use http::{HeaderValue, Request, Response, StatusCode};
 use tonic::body::Body as TonicBody;
 use tower::{Layer, Service};
 
-/// Rate limiter type
+/// Per-IP rate limiter. IPv6 addresses are keyed by their `/64` prefix so a single
+/// routable prefix cannot bypass the limiter by rotating addresses.
 pub type IpRateLimiter =
     RateLimiter<IpAddr, DashMapStateStore<IpAddr>, DefaultClock, NoOpMiddleware<QuantaInstant>>;
 
-/// Configuration for rate limiting
+/// How often idle-IP entries are purged from the state store.
+const RETAIN_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Configuration for rate limiting.
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
-    /// Maximum requests per second per IP
-    pub requests_per_second: u32,
-    /// Allow temporary spikes
-    pub burst_size: u32,
+    /// Sustained requests per second per IP.
+    pub requests_per_second: NonZeroU32,
+    /// Maximum burst size (tokens in the bucket).
+    pub burst_size: NonZeroU32,
+    /// Trust `X-Forwarded-For` / `X-Real-IP` when identifying the client.
+    ///
+    /// Only enable when the server sits behind a trusted reverse proxy that
+    /// overwrites these headers — otherwise any client can bypass the limiter
+    /// by setting the header themselves.
+    pub trust_forwarded_headers: bool,
 }
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
-        Self { requests_per_second: 50, burst_size: 100 }
+        Self {
+            requests_per_second: NonZeroU32::new(50).expect("50 is non-zero"),
+            burst_size: NonZeroU32::new(100).expect("100 is non-zero"),
+            trust_forwarded_headers: false,
+        }
     }
 }
 
-/// Tower layer for per-IP rate limiting
+/// Tower layer for per-IP rate limiting.
 #[derive(Clone)]
 pub struct RateLimitLayer {
     limiter: Arc<IpRateLimiter>,
+    trust_forwarded_headers: bool,
 }
 
 impl RateLimitLayer {
-    /// Create a new rate limit layer from config
+    /// Build a layer and spawn a background task that evicts idle-IP entries
+    /// from the state store so it cannot grow unbounded. Must be called from
+    /// inside a tokio runtime.
     pub fn new(config: &RateLimitConfig) -> Self {
-        let quota = Quota::per_second(
-            NonZeroU32::new(config.requests_per_second).unwrap_or(NonZeroU32::MIN),
-        )
-        .allow_burst(NonZeroU32::new(config.burst_size).unwrap_or(NonZeroU32::MIN));
+        let quota = Quota::per_second(config.requests_per_second).allow_burst(config.burst_size);
+        let limiter = Arc::new(RateLimiter::dashmap(quota));
+
+        tokio::spawn({
+            let limiter = limiter.clone();
+            async move {
+                let mut interval = tokio::time::interval(RETAIN_INTERVAL);
+                interval.tick().await; // skip the immediate first tick
+                loop {
+                    interval.tick().await;
+                    limiter.retain_recent();
+                }
+            }
+        });
 
         Self {
-            limiter: Arc::new(RateLimiter::dashmap(quota)),
+            limiter,
+            trust_forwarded_headers: config.trust_forwarded_headers,
         }
     }
 }
@@ -54,58 +83,76 @@ impl<S> Layer<S> for RateLimitLayer {
     type Service = RateLimitService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        RateLimitService { inner, limiter: self.limiter.clone() }
+        RateLimitService {
+            inner,
+            limiter: self.limiter.clone(),
+            trust_forwarded_headers: self.trust_forwarded_headers,
+        }
     }
 }
 
-/// Rate limiting service that wraps an inner service
+/// Rate-limiting service wrapping an inner service.
 #[derive(Clone)]
 pub struct RateLimitService<S> {
     inner: S,
     limiter: Arc<IpRateLimiter>,
+    trust_forwarded_headers: bool,
 }
 
 impl<S> RateLimitService<S> {
-    /// Extract client IP from request
-    ///
-    /// Checks headers in order:
-    /// 1. `x-forwarded-for` (first IP in the chain, from reverse proxy)
-    /// 2. `x-real-ip` (common alternative header)
-    /// 3. Connected peer address (direct connection)
-    /// 4. Fallback to localhost
-    fn extract_ip<B>(req: &Request<B>) -> IpAddr {
-        // Try X-Forwarded-For header first (for reverse proxy setups)
-        if let Some(forwarded_for) = req.headers().get("x-forwarded-for") {
-            if let Ok(header_str) = forwarded_for.to_str() {
-                // Take the first IP in the chain (original client)
-                if let Some(first_ip) = header_str.split(',').next() {
-                    if let Ok(ip) = first_ip.trim().parse::<IpAddr>() {
-                        return ip;
-                    }
-                }
+    /// Client IP used for rate-limit bucketing, or `None` if it cannot be
+    /// determined (in which case the request is allowed through — we prefer
+    /// that over lumping unrelated requests into a shared bucket).
+    fn extract_ip<B>(&self, req: &Request<B>) -> Option<IpAddr> {
+        if self.trust_forwarded_headers {
+            if let Some(ip) = req.headers().get("x-forwarded-for").and_then(parse_forwarded_for) {
+                return Some(ip);
+            }
+            if let Some(ip) = req.headers().get("x-real-ip").and_then(parse_single_ip) {
+                return Some(ip);
             }
         }
 
-        // Try X-Real-IP header
-        if let Some(real_ip) = req.headers().get("x-real-ip") {
-            if let Ok(header_str) = real_ip.to_str() {
-                if let Ok(ip) = header_str.trim().parse::<IpAddr>() {
-                    return ip;
-                }
-            }
-        }
-
-        // Fall back to connected peer address from extensions
-        if let Some(addr) = req.extensions().get::<tonic::transport::server::TcpConnectInfo>() {
-            if let Some(remote_addr) = addr.remote_addr() {
-                return remote_addr.ip();
-            }
-        }
-
-        // Last resort: use localhost
-        // Ensures we don't fail the request, but rate limits unknown sources together
-        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+        req.extensions()
+            .get::<tonic::transport::server::TcpConnectInfo>()
+            .and_then(tonic::transport::server::TcpConnectInfo::remote_addr)
+            .map(|addr| addr.ip())
     }
+}
+
+fn parse_forwarded_for(value: &HeaderValue) -> Option<IpAddr> {
+    value.to_str().ok()?.split(',').next()?.trim().parse().ok()
+}
+
+fn parse_single_ip(value: &HeaderValue) -> Option<IpAddr> {
+    value.to_str().ok()?.trim().parse().ok()
+}
+
+/// A single attacker with a routable `/64` can otherwise rotate through 2^64
+/// addresses and dodge the limiter entirely.
+fn bucket(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4(_) => ip,
+        IpAddr::V6(v6) => {
+            let mut octets = v6.octets();
+            for o in &mut octets[8..] {
+                *o = 0;
+            }
+            IpAddr::V6(Ipv6Addr::from(octets))
+        },
+    }
+}
+
+/// Trailers-only gRPC response: HTTP 200 with `grpc-status: 8`
+/// (`RESOURCE_EXHAUSTED`) — the canonical gRPC mapping for rate-limit rejection.
+fn rate_limit_exceeded_response() -> Response<TonicBody> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/grpc")
+        .header("grpc-status", "8")
+        .header("grpc-message", "rate limit exceeded")
+        .body(TonicBody::empty())
+        .expect("static rate-limit response is valid")
 }
 
 impl<S, ReqBody> Service<Request<ReqBody>> for RateLimitService<S>
@@ -124,22 +171,92 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let ip = Self::extract_ip(&req);
-
-        // Check rate limit
-        if self.limiter.check_key(&ip).is_err() {
-            // return 429
-            let response = Response::builder()
-                .status(StatusCode::TOO_MANY_REQUESTS)
-                .header("content-type", "application/grpc")
-                .header("grpc-status", "14") // unavailable
-                .header("grpc-message", "rate limit exceeded")
-                .body(TonicBody::empty())
-                .unwrap();
-
-            return futures::future::Either::Right(std::future::ready(Ok(response)));
+        if let Some(ip) = self.extract_ip(&req) {
+            if self.limiter.check_key(&bucket(ip)).is_err() {
+                return futures::future::Either::Right(std::future::ready(Ok(
+                    rate_limit_exceeded_response(),
+                )));
+            }
         }
 
         futures::future::Either::Left(self.inner.call(req))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn req_with_headers(headers: &[(&'static str, &str)]) -> Request<()> {
+        let mut req = Request::builder().body(()).unwrap();
+        for (name, value) in headers {
+            req.headers_mut().insert(*name, HeaderValue::from_str(value).unwrap());
+        }
+        req
+    }
+
+    fn service(trust_forwarded_headers: bool) -> RateLimitService<()> {
+        let cfg = RateLimitConfig {
+            trust_forwarded_headers,
+            ..Default::default()
+        };
+        RateLimitLayer::new(&cfg).layer(())
+    }
+
+    #[tokio::test]
+    async fn extract_ip_honors_forwarded_for_when_trusted() {
+        let svc = service(true);
+        let req = req_with_headers(&[("x-forwarded-for", "203.0.113.1, 10.0.0.1")]);
+        assert_eq!(svc.extract_ip(&req), Some("203.0.113.1".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn extract_ip_ignores_forwarded_for_when_untrusted() {
+        let svc = service(false);
+        let req = req_with_headers(&[("x-forwarded-for", "203.0.113.1")]);
+        assert_eq!(svc.extract_ip(&req), None);
+    }
+
+    #[tokio::test]
+    async fn extract_ip_falls_back_to_real_ip_when_trusted() {
+        let svc = service(true);
+        let req = req_with_headers(&[("x-real-ip", "198.51.100.7")]);
+        assert_eq!(svc.extract_ip(&req), Some("198.51.100.7".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn extract_ip_ignores_malformed_forwarded_for() {
+        let svc = service(true);
+        let req = req_with_headers(&[("x-forwarded-for", "not-an-ip")]);
+        assert_eq!(svc.extract_ip(&req), None);
+    }
+
+    #[test]
+    fn bucket_masks_ipv6_to_slash_64() {
+        let ip: IpAddr = "2001:db8:1:2:dead:beef:cafe:1".parse().unwrap();
+        let expected: IpAddr = "2001:db8:1:2::".parse().unwrap();
+        assert_eq!(bucket(ip), expected);
+    }
+
+    #[test]
+    fn bucket_preserves_ipv4() {
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7));
+        assert_eq!(bucket(ip), ip);
+    }
+
+    #[tokio::test]
+    async fn over_quota_requests_are_rejected() {
+        let cfg = RateLimitConfig {
+            requests_per_second: NonZeroU32::new(1).unwrap(),
+            burst_size: NonZeroU32::new(1).unwrap(),
+            trust_forwarded_headers: true,
+        };
+        let layer = RateLimitLayer::new(&cfg);
+        let ip: IpAddr = "203.0.113.10".parse().unwrap();
+
+        assert!(layer.limiter.check_key(&ip).is_ok(), "first request should pass");
+        assert!(layer.limiter.check_key(&ip).is_err(), "second request should be rate-limited");
     }
 }


### PR DESCRIPTION
Draft PR against `ev/fmt` (PR #60) with the review fixes from https://github.com/0xMiden/note-transport-service/pull/60#issuecomment- (review I posted locally).

## Summary

- Canonical gRPC status: trailers-only HTTP 200 with `grpc-status: 8` (`RESOURCE_EXHAUSTED`) instead of HTTP 429 with `grpc-status: 14` (`UNAVAILABLE`). Clients apply very different retry policies to these two codes.
- X-Forwarded-For / X-Real-IP trust is now opt-in via `trust_forwarded_headers` (default false) + `--rate-limit-trust-forwarded-headers` CLI flag. Trusting these unconditionally let any direct client bypass the limiter by spoofing the header. Also removed the `LOCALHOST` fallback that coalesced unidentifiable traffic into a shared bucket.
- IPv6 addresses are bucketed by `/64` prefix before being keyed, so a single routable `/64` cannot rotate through 2^64 addresses to dodge the limiter.
- `governor`'s dashmap state store is now periodically cleaned by a background tokio task calling `retain_recent()` every 60s, preventing unbounded memory growth.
- `requests_per_second` / `burst_size` are now `NonZeroU32` in the config and on the CLI, so `--rate-limit-rps 0` fails at parse time instead of being silently clamped to 1.
- `governor` and `http` are now referenced via `[workspace.dependencies]` to match the rest of the crate.
- Unit tests for `extract_ip` precedence + trust-flag gating, IPv6 `/64` bucketing, and a smoke test that over-quota requests hit `RESOURCE_EXHAUSTED`.

## Test plan

- [x] `cargo test --workspace --all-targets` (12 tests pass, 7 new)
- [x] `make lint` (fmt + fix + clippy + toml + workspace-lints)
- [ ] Manual test against a running node with a low `--rate-limit-rps` + `grpcurl` to confirm the `RESOURCE_EXHAUSTED` response shape
- [ ] Verify X-Forwarded-For flag behavior behind nginx

Worktree: `/home/marti/dev/note-transport-service/.claude/worktrees/rate-limit-review-fixes`.
Branch: `mmagician-claude/rate-limit-review-fixes`, based off the `ev/fmt` head (93ffd74).