### PR TITLE
fix: close private-note pagination race and :memory: pool-isolation bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node-bin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "miden-note-transport-node",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fs-err",
  "miette",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-note-transport"
 rust-version = "1.87"
-version      = "0.3.1"
+version      = "0.3.2"
 
 [workspace.dependencies]
 # Workspace crates (path-based dependencies)
-miden-note-transport-node        = { path = "crates/node", version = "0.3.1" }
-miden-note-transport-proto       = { path = "crates/proto", version = "0.3.1" }
-miden-note-transport-proto-build = { path = "proto", version = "0.3.1" }
+miden-note-transport-node        = { path = "crates/node", version = "0.3.2" }
+miden-note-transport-proto       = { path = "crates/proto", version = "0.3.2" }
+miden-note-transport-proto-build = { path = "proto", version = "0.3.2" }
 
 # miden-base aka protocol dependencies (git = "https://github.com/0xMiden/miden-base"). These should be updated in sync.
 miden-protocol = { default-features = false, version = "0.14.0" }

--- a/crates/node/src/database/maintenance.rs
+++ b/crates/node/src/database/maintenance.rs
@@ -74,6 +74,7 @@ mod tests {
             header: test_note_header(),
             details: vec![1, 2, 3, 4],
             created_at: Utc::now() - age,
+            seq: 0, // ignored on INSERT
         }
     }
 

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -432,4 +432,87 @@ mod tests {
             "the interleaved tag-A insert MUST be visible via the single-snapshot query"
         );
     }
+
+    /// Legacy cursor reset: a client carrying a pre-migration microsecond-
+    /// timestamp cursor (e.g. 1.7×10^15) would otherwise see 0 notes until
+    /// `seq` reached that magnitude, which at realistic rates is decades.
+    /// Cursors above `LEGACY_CURSOR_THRESHOLD` are treated as 0.
+    #[tokio::test]
+    async fn test_fetch_notes_resets_legacy_cursor() {
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        let note = StoredNote {
+            header: test_note_header(),
+            details: vec![1, 2, 3, 4],
+            created_at: Utc::now(),
+            seq: 0,
+        };
+        db.store_note(&note).await.unwrap();
+
+        // A realistic "legacy" cursor — microseconds since the epoch, currently
+        // ~1.76×10^15. Well above the 10^12 threshold.
+        let legacy_cursor: u64 = 1_760_000_000_000_000;
+        let fetched = db.fetch_notes(TAG_LOCAL_ANY.into(), legacy_cursor).await.unwrap();
+        assert_eq!(
+            fetched.len(),
+            1,
+            "legacy microsecond cursor should be reset to 0, returning the note"
+        );
+
+        // Sanity check: a non-legacy cursor above the note's seq should NOT trigger the reset.
+        let normal_cursor: u64 = 1_000;
+        let empty = db.fetch_notes(TAG_LOCAL_ANY.into(), normal_cursor).await.unwrap();
+        assert_eq!(empty.len(), 0, "normal cursor > seq should filter correctly");
+    }
+
+    /// Pagination: a response is capped at `FETCH_NOTES_BATCH_SIZE` rows. A
+    /// backlogged client sees a bounded batch on each call and advances the
+    /// cursor to pick up the rest on the next call.
+    #[tokio::test]
+    async fn test_fetch_notes_paginates_at_batch_limit() {
+        use crate::database::sqlite::FETCH_NOTES_BATCH_SIZE;
+
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        // Insert BATCH_SIZE + extra notes for the same tag.
+        let extra: usize = 7;
+        let total = usize::try_from(FETCH_NOTES_BATCH_SIZE).unwrap() + extra;
+        for i in 0..total {
+            db.store_note(&StoredNote {
+                header: test_note_header(),
+                details: vec![(i % 256) as u8],
+                created_at: Utc::now(),
+                seq: 0,
+            })
+            .await
+            .unwrap();
+        }
+
+        // First fetch from cursor=0 returns exactly BATCH_SIZE rows.
+        let first = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        assert_eq!(
+            i64::try_from(first.len()).unwrap(),
+            FETCH_NOTES_BATCH_SIZE,
+            "first batch must be capped at FETCH_NOTES_BATCH_SIZE"
+        );
+
+        // Advance cursor to max(seq) and refetch — remaining rows come back.
+        let advanced: u64 = first.iter().map(|n| u64::try_from(n.seq).unwrap()).max().unwrap();
+        let second = db.fetch_notes(TAG_LOCAL_ANY.into(), advanced).await.unwrap();
+        assert_eq!(second.len(), extra, "second batch must contain the remaining {extra} rows");
+
+        // Third fetch drains nothing (nothing left).
+        let third_cursor: u64 =
+            second.iter().map(|n| u64::try_from(n.seq).unwrap()).max().unwrap_or(advanced);
+        let third = db.fetch_notes(TAG_LOCAL_ANY.into(), third_cursor).await.unwrap();
+        assert_eq!(third.len(), 0, "drained");
+
+        // Stats reflect every row written.
+        let (total_stats, _) = db.get_stats().await.unwrap();
+        assert_eq!(usize::try_from(total_stats).unwrap(), total);
+    }
 }

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -282,4 +282,154 @@ mod tests {
         let after = db.fetch_notes(TAG_LOCAL_ANY.into(), cursor).await.unwrap();
         assert_eq!(after.len(), 0);
     }
+
+    /// Deterministic regression test for the seq-cursor fix.
+    ///
+    /// Two notes with IDENTICAL `created_at` microseconds (possible on macOS
+    /// under concurrent writes; more broadly, any system where wall-clock is
+    /// not injective under load). With the old `created_at` cursor, the
+    /// client's `rcursor = max(ts)` strict-greater filter rendered the 2nd
+    /// note permanently invisible. With the `seq` cursor, each note gets a
+    /// distinct monotonic id and both are reachable.
+    #[tokio::test]
+    async fn test_seq_cursor_survives_identical_created_at() {
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        let t = Utc::now();
+        let note1 = StoredNote {
+            header: test_note_header(),
+            details: vec![1],
+            created_at: t,
+            seq: 0,
+        };
+        db.store_note(&note1).await.unwrap();
+
+        // Client's first fetch sees note1, advances cursor using the returned seq.
+        let first = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        assert_eq!(first.len(), 1);
+        let cursor = u64::try_from(first[0].seq).expect("seq is non-negative");
+
+        // A concurrent writer commits note2 with the SAME `created_at`.
+        let note2 = StoredNote {
+            header: test_note_header(),
+            details: vec![2],
+            created_at: t,
+            seq: 0,
+        };
+        db.store_note(&note2).await.unwrap();
+
+        // With seq cursor: note2 has seq > cursor → returned.
+        // With old timestamp cursor: note2.ts == cursor → filtered by strict `>` → LOST.
+        let second = db.fetch_notes(TAG_LOCAL_ANY.into(), cursor).await.unwrap();
+        assert_eq!(
+            second.len(),
+            1,
+            "seq cursor must return note2 despite identical created_at; got {} notes",
+            second.len()
+        );
+        assert_eq!(second[0].details, vec![2]);
+    }
+
+    /// Deterministic regression test for the multi-tag single-snapshot fix.
+    ///
+    /// Simulates the old gRPC handler's per-tag loop: fetch tag A, then fetch
+    /// tag B, then advance client cursor to `max(seq)` across both results.
+    /// A concurrent tag-A insert landing between the per-tag queries gets a
+    /// seq ABOVE A's max but BELOW B's max — so when the client advances to
+    /// B's max seq, the A insert becomes permanently unreachable (its seq is
+    /// below the advanced cursor).
+    ///
+    /// `fetch_notes_by_tags` collapses the loop into a single `tag IN (…)`
+    /// query under one snapshot, so no interleave is possible.
+    #[tokio::test]
+    async fn test_multi_tag_single_snapshot_vs_per_tag_loop() {
+        use std::convert::TryFrom;
+
+        const TAG_A: u32 = 0x3d9c_0000;
+        const TAG_B: u32 = 0x47ac_0000;
+
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        // Seed: one pre-existing tag A note.
+        db.store_note(&StoredNote {
+            header: test_note_header_with_tag(TAG_A),
+            details: vec![1],
+            created_at: Utc::now(),
+            seq: 0,
+        })
+        .await
+        .unwrap();
+
+        // === Simulate the old per-tag loop ===
+        // Step 1: fetch tag A.
+        let a_result = db.fetch_notes(TAG_A.into(), 0).await.unwrap();
+        assert_eq!(a_result.len(), 1);
+
+        // Between the per-tag queries, two concurrent writes commit in order:
+        //   (i) a tag A note — this is the one the loop will lose.
+        //  (ii) a tag B note — its higher seq will bump the client's cursor
+        //       past (i), rendering (i) unreachable on retry.
+        db.store_note(&StoredNote {
+            header: test_note_header_with_tag(TAG_A),
+            details: vec![2],
+            created_at: Utc::now(),
+            seq: 0,
+        })
+        .await
+        .unwrap();
+        db.store_note(&StoredNote {
+            header: test_note_header_with_tag(TAG_B),
+            details: vec![3],
+            created_at: Utc::now(),
+            seq: 0,
+        })
+        .await
+        .unwrap();
+
+        // Step 2: fetch tag B.
+        let b_result = db.fetch_notes(TAG_B.into(), 0).await.unwrap();
+        assert_eq!(b_result.len(), 1);
+
+        // Client advances cursor to max(seq) across both results, mirroring the
+        // gRPC handler's `rcursor` computation.
+        let rcursor: u64 = a_result
+            .iter()
+            .chain(b_result.iter())
+            .map(|n| u64::try_from(n.seq).unwrap())
+            .max()
+            .unwrap_or(0);
+
+        // Client's next per-tag fetches with the advanced cursor.
+        let retry_a = db.fetch_notes(TAG_A.into(), rcursor).await.unwrap();
+        let retry_b = db.fetch_notes(TAG_B.into(), rcursor).await.unwrap();
+
+        // Per-tag loop sees only 2 of the 3 notes — the interleaved tag A
+        // insert with the details=[2] payload is missing.
+        let per_tag_visible = a_result.len() + b_result.len() + retry_a.len() + retry_b.len();
+        assert_eq!(
+            per_tag_visible, 2,
+            "per-tag loop must lose the interleaved tag-A insert; visible = {per_tag_visible}"
+        );
+        assert!(
+            !retry_a.iter().any(|n| n.details == vec![2]),
+            "the interleaved tag-A insert with details=[2] must be unreachable to the per-tag loop"
+        );
+
+        // === The fix: single-snapshot multi-tag query ===
+        let snapshot = db.fetch_notes_by_tags(&[TAG_A.into(), TAG_B.into()], 0).await.unwrap();
+        assert_eq!(
+            snapshot.len(),
+            3,
+            "fetch_notes_by_tags must return all 3 notes in a single consistent snapshot; got {}",
+            snapshot.len()
+        );
+        assert!(
+            snapshot.iter().any(|n| n.details == vec![2]),
+            "the interleaved tag-A insert MUST be visible via the single-snapshot query"
+        );
+    }
 }

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -142,6 +142,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_seq_assigned_monotonically_in_insert_order() {
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        let first = StoredNote {
+            header: test_note_header(),
+            details: vec![1],
+            created_at: Utc::now(),
+            seq: 0,
+        };
+        db.store_note(&first).await.unwrap();
+
+        let second = StoredNote {
+            header: test_note_header(),
+            details: vec![2],
+            created_at: Utc::now(),
+            seq: 0,
+        };
+        db.store_note(&second).await.unwrap();
+
+        // Fetch everything and assert INSERT order = read order = seq ascending.
+        let fetched = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert!(fetched[0].seq < fetched[1].seq, "expected monotonic seq; got {} then {}", fetched[0].seq, fetched[1].seq);
+        assert_eq!(fetched[0].details, vec![1]);
+        assert_eq!(fetched[1].details, vec![2]);
+
+        // Cursor between the two seqs returns only the second.
+        let mid_cursor = fetched[0].seq as u64;
+        let after_first = db.fetch_notes(TAG_LOCAL_ANY.into(), mid_cursor).await.unwrap();
+        assert_eq!(after_first.len(), 1);
+        assert_eq!(after_first[0].details, vec![2]);
+    }
+
+    #[tokio::test]
     async fn test_fetch_notes_seq_cursor_filtering() {
         let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
             .await

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -116,22 +116,21 @@ mod tests {
         let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
             .await
             .unwrap();
-        let start = Utc::now();
 
         let note = StoredNote {
             header: test_note_header(),
             details: vec![1, 2, 3, 4],
             created_at: Utc::now(),
+            seq: 0, // ignored on INSERT
         };
 
         db.store_note(&note).await.unwrap();
 
-        let fetched_notes = db
-            .fetch_notes(TAG_LOCAL_ANY.into(), start.timestamp_micros().try_into().unwrap())
-            .await
-            .unwrap();
+        // Cursor is now seq-based; 0 fetches everything.
+        let fetched_notes = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
         assert_eq!(fetched_notes.len(), 1);
         assert_eq!(fetched_notes[0].header.id(), note.header.id());
+        assert!(fetched_notes[0].seq > 0);
 
         // Test note exists
         assert!(db.note_exists(note.header.id()).await.unwrap());
@@ -143,36 +142,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_notes_timestamp_filtering() {
+    async fn test_fetch_notes_seq_cursor_filtering() {
         let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
             .await
             .unwrap();
 
-        // Create a note with a specific received_at time
-        let received_time = Utc::now();
         let note = StoredNote {
             header: test_note_header(),
             details: vec![1, 2, 3, 4],
-            created_at: received_time,
+            created_at: Utc::now(),
+            seq: 0, // ignored on INSERT
         };
 
         db.store_note(&note).await.unwrap();
 
-        // Fetch notes with cursor before the note was received - should return the note
-        let before_cursor = (received_time - chrono::Duration::seconds(1))
-            .timestamp_micros()
-            .try_into()
-            .unwrap();
-        let fetched_notes = db.fetch_notes(TAG_LOCAL_ANY.into(), before_cursor).await.unwrap();
-        assert_eq!(fetched_notes.len(), 1);
-        assert_eq!(fetched_notes[0].header.id(), note.header.id());
+        // cursor=0 is strictly before any assigned seq → should return the note
+        let fetched = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        assert_eq!(fetched.len(), 1);
+        let stored_seq = fetched[0].seq;
+        assert!(stored_seq > 0, "expected seq > 0, got {stored_seq}");
 
-        // Fetch notes with cursor after the note was received - should return empty
-        let after_cursor = (received_time + chrono::Duration::seconds(1))
-            .timestamp_micros()
-            .try_into()
-            .unwrap();
-        let fetched_notes = db.fetch_notes(TAG_LOCAL_ANY.into(), after_cursor).await.unwrap();
-        assert_eq!(fetched_notes.len(), 0);
+        // cursor = the note's own seq → strictly-greater filter excludes it
+        let after = db.fetch_notes(TAG_LOCAL_ANY.into(), stored_seq as u64).await.unwrap();
+        assert_eq!(after.len(), 0);
     }
 }

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -29,6 +29,17 @@ pub trait DatabaseBackend: Send + Sync {
         cursor: u64,
     ) -> Result<Vec<StoredNote>, DatabaseError>;
 
+    /// Fetch notes matching ANY of a set of tags, in a single DB snapshot.
+    ///
+    /// This is the preferred multi-tag query — running per-tag queries back
+    /// to back reopens a race where a concurrent INSERT can land between two
+    /// per-tag queries and get leapfrogged by the cursor advance.
+    async fn fetch_notes_by_tags(
+        &self,
+        tags: &[NoteTag],
+        cursor: u64,
+    ) -> Result<Vec<StoredNote>, DatabaseError>;
+
     /// Get statistics about the database
     async fn get_stats(&self) -> Result<(u64, u64), DatabaseError>;
 
@@ -85,6 +96,15 @@ impl Database {
         cursor: u64,
     ) -> Result<Vec<StoredNote>, DatabaseError> {
         self.backend.fetch_notes(tag, cursor).await
+    }
+
+    /// Fetch notes matching ANY of a set of tags, in a single DB snapshot.
+    pub async fn fetch_notes_by_tags(
+        &self,
+        tags: &[NoteTag],
+        cursor: u64,
+    ) -> Result<Vec<StoredNote>, DatabaseError> {
+        self.backend.fetch_notes_by_tags(tags, cursor).await
     }
 
     /// Get statistics about the database

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -109,7 +109,7 @@ mod tests {
 
     use super::*;
     use crate::metrics::Metrics;
-    use crate::test_utils::{TAG_LOCAL_ANY, test_note_header};
+    use crate::test_utils::{TAG_LOCAL_ANY, test_note_header, test_note_header_with_tag};
 
     #[tokio::test]
     async fn test_sqlite_database() {
@@ -175,6 +175,53 @@ mod tests {
         let after_first = db.fetch_notes(TAG_LOCAL_ANY.into(), mid_cursor).await.unwrap();
         assert_eq!(after_first.len(), 1);
         assert_eq!(after_first[0].details, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_store_fetch_sees_all_rows() {
+        // Regression test for the `:memory:` pool-isolation bug: when the pool
+        // had max_size>1 and the URL was `:memory:`, writes and reads could
+        // land on different connections and each connection had its own
+        // isolated in-memory DB. Result: writes silently split across pool
+        // connections, fetches only saw a fraction of the actual data.
+        //
+        // With the pool clamped to size=1 for `:memory:`, all ops go to the
+        // same connection and see the same DB.
+        use std::sync::Arc;
+        use tokio::task::JoinSet;
+
+        const TAG_A: u32 = 0x3d9c_0000;
+        const TAG_B: u32 = 0x47ac_0000;
+
+        let db = Arc::new(
+            Database::connect(DatabaseConfig::default(), Metrics::default().db).await.unwrap(),
+        );
+
+        // Spawn many concurrent writers — more than the old max_size=16 — so
+        // that the bug would have fragmented writes across connections.
+        let mut writers = JoinSet::new();
+        for i in 0..40u32 {
+            let db = db.clone();
+            writers.spawn(async move {
+                let tag = if i % 2 == 0 { TAG_A } else { TAG_B };
+                db.store_note(&StoredNote {
+                    header: test_note_header_with_tag(tag),
+                    details: vec![i as u8],
+                    created_at: Utc::now(),
+                    seq: 0,
+                })
+                .await
+                .unwrap();
+            });
+        }
+        while writers.join_next().await.is_some() {}
+
+        let fetched_a = db.fetch_notes(TAG_A.into(), 0).await.unwrap();
+        let fetched_b = db.fetch_notes(TAG_B.into(), 0).await.unwrap();
+        assert_eq!(fetched_a.len() + fetched_b.len(), 40, "all 40 concurrent writes should be visible");
+
+        let (total, _) = db.get_stats().await.unwrap();
+        assert_eq!(total, 40, "stats should reflect all 40 rows");
     }
 
     #[tokio::test]

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -186,12 +186,17 @@ mod tests {
         // Fetch everything and assert INSERT order = read order = seq ascending.
         let fetched = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
         assert_eq!(fetched.len(), 2);
-        assert!(fetched[0].seq < fetched[1].seq, "expected monotonic seq; got {} then {}", fetched[0].seq, fetched[1].seq);
+        assert!(
+            fetched[0].seq < fetched[1].seq,
+            "expected monotonic seq; got {} then {}",
+            fetched[0].seq,
+            fetched[1].seq
+        );
         assert_eq!(fetched[0].details, vec![1]);
         assert_eq!(fetched[1].details, vec![2]);
 
         // Cursor between the two seqs returns only the second.
-        let mid_cursor = fetched[0].seq as u64;
+        let mid_cursor = u64::try_from(fetched[0].seq).expect("seq is non-negative");
         let after_first = db.fetch_notes(TAG_LOCAL_ANY.into(), mid_cursor).await.unwrap();
         assert_eq!(after_first.len(), 1);
         assert_eq!(after_first[0].details, vec![2]);
@@ -208,13 +213,16 @@ mod tests {
         // With the pool clamped to size=1 for `:memory:`, all ops go to the
         // same connection and see the same DB.
         use std::sync::Arc;
+
         use tokio::task::JoinSet;
 
         const TAG_A: u32 = 0x3d9c_0000;
         const TAG_B: u32 = 0x47ac_0000;
 
         let db = Arc::new(
-            Database::connect(DatabaseConfig::default(), Metrics::default().db).await.unwrap(),
+            Database::connect(DatabaseConfig::default(), Metrics::default().db)
+                .await
+                .unwrap(),
         );
 
         // Spawn many concurrent writers — more than the old max_size=16 — so
@@ -238,7 +246,11 @@ mod tests {
 
         let fetched_a = db.fetch_notes(TAG_A.into(), 0).await.unwrap();
         let fetched_b = db.fetch_notes(TAG_B.into(), 0).await.unwrap();
-        assert_eq!(fetched_a.len() + fetched_b.len(), 40, "all 40 concurrent writes should be visible");
+        assert_eq!(
+            fetched_a.len() + fetched_b.len(),
+            40,
+            "all 40 concurrent writes should be visible"
+        );
 
         let (total, _) = db.get_stats().await.unwrap();
         assert_eq!(total, 40, "stats should reflect all 40 rows");
@@ -266,7 +278,8 @@ mod tests {
         assert!(stored_seq > 0, "expected seq > 0, got {stored_seq}");
 
         // cursor = the note's own seq → strictly-greater filter excludes it
-        let after = db.fetch_notes(TAG_LOCAL_ANY.into(), stored_seq as u64).await.unwrap();
+        let cursor = u64::try_from(stored_seq).expect("seq is non-negative");
+        let after = db.fetch_notes(TAG_LOCAL_ANY.into(), cursor).await.unwrap();
         assert_eq!(after.len(), 0);
     }
 }

--- a/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/down.sql
+++ b/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/down.sql
@@ -1,0 +1,16 @@
+CREATE TABLE notes_old (
+    id BLOB PRIMARY KEY,
+    tag INTEGER NOT NULL,
+    header BLOB NOT NULL,
+    details BLOB NOT NULL,
+    created_at INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO notes_old (id, tag, header, details, created_at)
+SELECT id, tag, header, details, created_at FROM notes;
+
+DROP TABLE notes;
+ALTER TABLE notes_old RENAME TO notes;
+
+CREATE INDEX idx_notes_tag ON notes(tag);
+CREATE INDEX idx_notes_created_at ON notes(created_at);

--- a/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/up.sql
+++ b/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/up.sql
@@ -1,0 +1,31 @@
+-- Replace the `notes` table with a monotonic INTEGER PRIMARY KEY (`seq`).
+--
+-- The previous `fetch_notes` pagination used `created_at` (microsecond
+-- timestamp) as the cursor, which is vulnerable to a race when multiple
+-- `send_note` inserts happen concurrently with a multi-tag fetch: a note can
+-- be inserted with a `created_at` lower than the `rcursor` returned for an
+-- earlier tag, leaving the note strictly under the next fetch's cursor and
+-- thus permanently unreachable.
+--
+-- `seq` is assigned at INSERT-commit time, monotonic, and survives VACUUM
+-- because of AUTOINCREMENT — INSERT order defines read order regardless of
+-- wall clock. See NotesNotDelivered.md in miden-wallet for the full writeup.
+
+CREATE TABLE notes_new (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    id BLOB NOT NULL UNIQUE,
+    tag INTEGER NOT NULL,
+    header BLOB NOT NULL,
+    details BLOB NOT NULL,
+    created_at INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO notes_new (id, tag, header, details, created_at)
+SELECT id, tag, header, details, created_at FROM notes
+ORDER BY created_at ASC;
+
+DROP TABLE notes;
+ALTER TABLE notes_new RENAME TO notes;
+
+CREATE INDEX idx_notes_tag ON notes(tag);
+CREATE INDEX idx_notes_created_at ON notes(created_at);

--- a/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/up.sql
+++ b/crates/node/src/database/sqlite/migrations/20260422000000_add_seq_cursor/up.sql
@@ -27,5 +27,9 @@ ORDER BY created_at ASC;
 DROP TABLE notes;
 ALTER TABLE notes_new RENAME TO notes;
 
-CREATE INDEX idx_notes_tag ON notes(tag);
+-- Compound (tag, seq) supports the hot pagination query
+--     WHERE tag = ? AND seq > ? ORDER BY seq ASC
+-- so the whole operation is index-only as the table grows.
+CREATE INDEX idx_notes_tag_seq ON notes(tag, seq);
+-- Kept for cleanup_old_notes (DELETE WHERE created_at < ?).
 CREATE INDEX idx_notes_created_at ON notes(created_at);

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -149,8 +149,14 @@ impl DatabaseBackend for SqliteDatabase {
 
         // Legacy cursor detection: clients upgraded from the pre-`seq` schema
         // carry microsecond-timestamp cursors; interpret those as 0 so they
-        // don't stall forever waiting for `seq` to catch up.
-        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD { 0 } else { cursor };
+        // don't stall forever waiting for `seq` to catch up. Record a metric
+        // so operators can see when pre-migration clients are being reset.
+        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD {
+            self.metrics.db_fetch_notes_legacy_cursor_reset();
+            0
+        } else {
+            cursor
+        };
 
         let cursor_i64: i64 = effective_cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -13,6 +13,24 @@ mod schema;
 use connection_manager::ConnectionManager;
 use models::{NewNote, Note};
 
+/// Maximum number of notes returned in a single `fetch_notes` / `fetch_notes_by_tags`
+/// response. Bounds memory on both the server (one DB buffer) and the client (one
+/// deserialized batch) regardless of how far behind the client's cursor is. A
+/// backlogged client paginates naturally by re-calling with the returned cursor.
+pub(crate) const FETCH_NOTES_BATCH_SIZE: i64 = 500;
+
+/// Threshold above which a `fetch_notes` cursor is interpreted as a legacy
+/// microsecond-timestamp cursor from the pre-`seq` schema and reset to 0.
+///
+/// Before the `seq`-cursor migration, cursors were `created_at.timestamp_micros()`
+/// — values near 1.7×10^15. After migration, cursors are `seq` values starting
+/// at 1. Without this reset, any client that stored a cursor before migration
+/// would see zero notes forever (until `seq` caught up to their old timestamp,
+/// which at realistic insert rates is decades). 10^12 is two orders of magnitude
+/// above any plausible `seq` value we'd reach in the lifetime of this deployment,
+/// and two orders of magnitude below any microsecond timestamp this decade.
+const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
+
 /// `SQLite` implementation of the database backend
 pub struct SqliteDatabase {
     pool: deadpool_diesel::Pool<ConnectionManager, deadpool::managed::Object<ConnectionManager>>,
@@ -129,7 +147,12 @@ impl DatabaseBackend for SqliteDatabase {
     ) -> Result<Vec<StoredNote>, DatabaseError> {
         let timer = self.metrics.db_fetch_notes();
 
-        let cursor_i64: i64 = cursor.try_into().map_err(|_| {
+        // Legacy cursor detection: clients upgraded from the pre-`seq` schema
+        // carry microsecond-timestamp cursors; interpret those as 0 so they
+        // don't stall forever waiting for `seq` to catch up.
+        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD { 0 } else { cursor };
+
+        let cursor_i64: i64 = effective_cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())
         })?;
 
@@ -144,6 +167,9 @@ impl DatabaseBackend for SqliteDatabase {
         // INSERT can't land between per-tag queries and get leapfrogged by the
         // cursor advance. This closes the second half of the pagination race
         // (the monotonic `seq` column closed the timestamp-collision half).
+        //
+        // LIMIT caps response size; a backlogged client paginates by re-calling
+        // with the returned cursor until the response is smaller than the limit.
         let notes: Vec<Note> = self
             .transact("fetch notes by tags", move |conn| {
                 use schema::notes::dsl::{notes, seq, tag};
@@ -151,6 +177,7 @@ impl DatabaseBackend for SqliteDatabase {
                     .filter(tag.eq_any(&tag_values))
                     .filter(seq.gt(cursor_i64))
                     .order(seq.asc())
+                    .limit(FETCH_NOTES_BATCH_SIZE)
                     .load::<Note>(conn)?;
                 Ok(fetched_notes)
             })

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -77,8 +77,8 @@ impl DatabaseBackend for SqliteDatabase {
         // return a partial view, which silently loses note data under load.
         //
         // Two ways to fix for an in-memory DB:
-        //   1. `file::memory:?cache=shared` — SQLite URI syntax that makes all
-        //      connections share the SAME in-memory DB via shared cache.
+        //   1. `file::memory:?cache=shared` — SQLite URI syntax that makes all connections share
+        //      the SAME in-memory DB via shared cache.
         //   2. Pool with `max_size=1` so only one connection exists.
         //
         // We pick #2 for simplicity and portability (URI mode requires the

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -71,9 +71,26 @@ impl DatabaseBackend for SqliteDatabase {
             })?;
         }
 
+        // SQLite `:memory:` DBs are per-connection-isolated — two connections
+        // pointing at `:memory:` see two different databases. With a pool of N
+        // connections, writes splinter across N isolated DBs and most reads
+        // return a partial view, which silently loses note data under load.
+        //
+        // Two ways to fix for an in-memory DB:
+        //   1. `file::memory:?cache=shared` — SQLite URI syntax that makes all
+        //      connections share the SAME in-memory DB via shared cache.
+        //   2. Pool with `max_size=1` so only one connection exists.
+        //
+        // We pick #2 for simplicity and portability (URI mode requires the
+        // `SQLITE_OPEN_URI` flag to be set on connection open, which is not the
+        // driver default). For file-backed URLs, a large pool is appropriate
+        // since all connections open the same file.
+        let is_in_memory = config.url == ":memory:" || config.url.starts_with("file::memory:");
+        let max_size = if is_in_memory { 1 } else { 16 };
+
         let manager = ConnectionManager::new(&config.url);
         let pool = deadpool_diesel::Pool::builder(manager)
-            .max_size(16)
+            .max_size(max_size)
             .build()
             .map_err(|e| DatabaseError::Pool(format!("Failed to create connection pool: {e}")))?;
 

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -110,11 +110,14 @@ impl DatabaseBackend for SqliteDatabase {
         let tag_value = i64::from(tag.as_u32());
         let notes: Vec<Note> = self
             .transact("fetch notes", move |conn| {
-                use schema::notes::dsl::{created_at, notes, tag};
+                // Paginate on `seq` (AUTOINCREMENT row id assigned at INSERT
+                // commit), not `created_at`. See migration
+                // 20260422000000_add_seq_cursor for the race this fixes.
+                use schema::notes::dsl::{notes, seq, tag};
                 let fetched_notes = notes
                     .filter(tag.eq(tag_value))
-                    .filter(created_at.gt(cursor_i64))
-                    .order(created_at.asc())
+                    .filter(seq.gt(cursor_i64))
+                    .order(seq.asc())
                     .load::<Note>(conn)?;
                 Ok(fetched_notes)
             })

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -118,21 +118,37 @@ impl DatabaseBackend for SqliteDatabase {
         tag: NoteTag,
         cursor: u64,
     ) -> Result<Vec<StoredNote>, DatabaseError> {
+        self.fetch_notes_by_tags(&[tag], cursor).await
+    }
+
+    #[tracing::instrument(skip(self, tags), fields(operation = "db.fetch_notes_by_tags"))]
+    async fn fetch_notes_by_tags(
+        &self,
+        tags: &[NoteTag],
+        cursor: u64,
+    ) -> Result<Vec<StoredNote>, DatabaseError> {
         let timer = self.metrics.db_fetch_notes();
 
         let cursor_i64: i64 = cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())
         })?;
 
-        let tag_value = i64::from(tag.as_u32());
+        if tags.is_empty() {
+            timer.finish("ok");
+            return Ok(Vec::new());
+        }
+
+        let tag_values: Vec<i64> = tags.iter().map(|t| i64::from(t.as_u32())).collect();
+
+        // Single query for all tags runs in ONE DB snapshot, so a concurrent
+        // INSERT can't land between per-tag queries and get leapfrogged by the
+        // cursor advance. This closes the second half of the pagination race
+        // (the monotonic `seq` column closed the timestamp-collision half).
         let notes: Vec<Note> = self
-            .transact("fetch notes", move |conn| {
-                // Paginate on `seq` (AUTOINCREMENT row id assigned at INSERT
-                // commit), not `created_at`. See migration
-                // 20260422000000_add_seq_cursor for the race this fixes.
+            .transact("fetch notes by tags", move |conn| {
                 use schema::notes::dsl::{notes, seq, tag};
                 let fetched_notes = notes
-                    .filter(tag.eq(tag_value))
+                    .filter(tag.eq_any(&tag_values))
                     .filter(seq.gt(cursor_i64))
                     .order(seq.asc())
                     .load::<Note>(conn)?;

--- a/crates/node/src/database/sqlite/models.rs
+++ b/crates/node/src/database/sqlite/models.rs
@@ -9,6 +9,7 @@ use crate::types::{NoteHeader, StoredNote};
 #[derive(Queryable, Selectable, Debug, Clone)]
 #[diesel(table_name = notes)]
 pub struct Note {
+    pub seq: i64,
     pub id: Vec<u8>,
     pub tag: i64,
     pub header: Vec<u8>,
@@ -16,6 +17,9 @@ pub struct Note {
     pub created_at: i64,
 }
 
+// `seq` is omitted from `NewNote`: SQLite auto-assigns it on INSERT via
+// INTEGER PRIMARY KEY AUTOINCREMENT, and we want INSERT-commit order (not
+// anything caller-provided) to define read order.
 #[derive(Insertable)]
 #[diesel(table_name = notes)]
 pub struct NewNote {
@@ -57,6 +61,7 @@ impl TryFrom<Note> for StoredNote {
             header,
             details: note.details,
             created_at,
+            seq: note.seq,
         })
     }
 }

--- a/crates/node/src/database/sqlite/schema.rs
+++ b/crates/node/src/database/sqlite/schema.rs
@@ -1,7 +1,8 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    notes (id) {
+    notes (seq) {
+        seq -> BigInt,
         id -> Binary,
         tag -> BigInt,
         header -> Binary,

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -37,6 +37,8 @@ pub struct MetricsDatabase {
     // fetch_notes()
     fetch_notes_count: Counter<u64>,
     fetch_notes_duration: Histogram<f64>,
+    // legacy cursor reset (pre-seq-migration clients)
+    fetch_notes_legacy_cursor_reset_count: Counter<u64>,
     // Maintenance
     maintenance_cleanup_notes_count: Counter<u64>,
     maintenance_cleanup_notes_duration: Histogram<f64>,
@@ -167,6 +169,15 @@ impl MetricsDatabase {
             .with_unit("s")
             .build();
 
+        let fetch_notes_legacy_cursor_reset_count = meter
+            .u64_counter("db_fetch_notes_legacy_cursor_reset_count")
+            .with_description(
+                "Number of fetch_notes() requests where the client's cursor was \
+                 above the legacy-cursor threshold and reset to 0 (pre-seq-migration \
+                 clients)",
+            )
+            .build();
+
         let maintenance_cleanup_notes_count = meter
             .u64_counter("db_maintenance_cleanup_notes_count")
             .with_description("Total number of DB maintenance cleanup_old_notes() requests")
@@ -183,6 +194,7 @@ impl MetricsDatabase {
             store_note_duration,
             fetch_notes_count,
             fetch_notes_duration,
+            fetch_notes_legacy_cursor_reset_count,
             maintenance_cleanup_notes_count,
             maintenance_cleanup_notes_duration,
         }
@@ -208,6 +220,11 @@ impl MetricsDatabase {
         let histogram = &self.fetch_notes_duration;
 
         request_count_measure(operation, counter, histogram)
+    }
+
+    /// Record a legacy-cursor reset (pre-seq-migration client).
+    pub fn db_fetch_notes_legacy_cursor_reset(&self) {
+        self.fetch_notes_legacy_cursor_reset_count.add(1, &[]);
     }
 
     /// Measure a DB maintenance cleanup-old-notes procedure

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -146,6 +146,8 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
             header,
             details: pnote.details,
             created_at: Utc::now(),
+            // Ignored on INSERT: the DB assigns seq via AUTOINCREMENT.
+            seq: 0,
         };
 
         self.database
@@ -177,12 +179,11 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
                 .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
             for stored_note in &stored_notes {
-                let ts_cursor: u64 = stored_note
-                    .created_at
-                    .timestamp_micros()
+                let seq_cursor: u64 = stored_note
+                    .seq
                     .try_into()
-                    .map_err(|_| tonic::Status::internal("Timestamp too large for cursor"))?;
-                rcursor = rcursor.max(ts_cursor);
+                    .map_err(|_| tonic::Status::internal("Negative seq in stored note"))?;
+                rcursor = rcursor.max(seq_cursor);
             }
 
             proto_notes.extend(stored_notes.into_iter().map(TransportNote::from));

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -29,6 +29,18 @@ use self::streaming::{NoteStreamer, StreamerMessage, Sub, Subface};
 use crate::database::Database;
 use crate::metrics::MetricsGrpc;
 
+/// Upper bound on the number of tags a client may include in a single
+/// `fetch_notes` request. Guards against two concerns:
+///   - Server CPU: deduplicating `request_data.tags` via `BTreeSet` is `O(n log n)`; a client
+///     sending millions of tags can burn a worker.
+///   - SQLite `IN (...)`: the underlying driver caps bound variables at
+///     `SQLITE_MAX_VARIABLE_NUMBER` (32766 on recent builds, lower on older); blow that and the
+///     query errors. Well below the SQLite cap so we have headroom for future query-plan changes.
+///
+/// A realistic wallet tracks O(10) to O(100) tags; 128 is generous without
+/// being an attack surface.
+const MAX_TAGS_PER_FETCH_REQUEST: usize = 128;
+
 /// Miden Note Transport gRPC server
 pub struct GrpcServer {
     database: Arc<Database>,
@@ -167,6 +179,20 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
         let timer = self.metrics.grpc_fetch_notes_request();
 
         let request_data = request.into_inner();
+
+        // Reject requests with too many tags BEFORE any allocation /
+        // deduplication work. A client sending `[0u32; 1_000_000]` would
+        // otherwise force an O(n log n) BTreeSet build and then either blow
+        // through `SQLITE_MAX_VARIABLE_NUMBER` or return a pathologically
+        // expensive query plan.
+        if request_data.tags.len() > MAX_TAGS_PER_FETCH_REQUEST {
+            return Err(Status::invalid_argument(format!(
+                "Too many tags in fetch_notes request: {} (max {})",
+                request_data.tags.len(),
+                MAX_TAGS_PER_FETCH_REQUEST
+            )));
+        }
+
         // Deduplicate incoming tags — the DB query is more efficient without repeats
         // and the previous per-tag loop happened to dedupe via BTreeSet.
         let tag_set: BTreeSet<_> = request_data.tags.into_iter().collect();
@@ -250,5 +276,62 @@ impl Drop for StreamerCtx {
             tracing::error!("Streamer shutdown message sending failure: {e}");
             self.handle.abort();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use miden_note_transport_proto::miden_note_transport::FetchNotesRequest;
+    use miden_note_transport_proto::miden_note_transport::miden_note_transport_server::MidenNoteTransport;
+
+    use super::*;
+    use crate::database::{Database, DatabaseConfig};
+    use crate::metrics::Metrics;
+
+    async fn test_server() -> GrpcServer {
+        let metrics = Metrics::default();
+        let db = Arc::new(
+            Database::connect(DatabaseConfig::default(), metrics.db.clone()).await.unwrap(),
+        );
+        GrpcServer::new(db, GrpcServerConfig::default(), metrics.grpc)
+    }
+
+    /// A client sending more tags than `MAX_TAGS_PER_FETCH_REQUEST` is rejected
+    /// with `InvalidArgument` BEFORE any `BTreeSet` or DB work. Guards against
+    /// both the O(n log n) dedup cost and the `SQLITE_MAX_VARIABLE_NUMBER`
+    /// ceiling.
+    #[tokio::test]
+    async fn test_fetch_notes_rejects_too_many_tags() {
+        let server = test_server().await;
+
+        let tags = vec![0u32; MAX_TAGS_PER_FETCH_REQUEST + 1];
+        let request = tonic::Request::new(FetchNotesRequest { tags, cursor: 0 });
+        let result = server.fetch_notes(request).await;
+
+        let status = result.expect_err("expected InvalidArgument");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status.message().contains("Too many tags"),
+            "unexpected error message: {}",
+            status.message()
+        );
+    }
+
+    /// A client sending exactly `MAX_TAGS_PER_FETCH_REQUEST` tags is accepted.
+    /// (Using the same tag value many times is fine — the handler dedups via
+    /// `BTreeSet` before issuing the query.)
+    #[tokio::test]
+    async fn test_fetch_notes_accepts_max_tags_at_limit() {
+        let server = test_server().await;
+
+        let tags = vec![0u32; MAX_TAGS_PER_FETCH_REQUEST];
+        let request = tonic::Request::new(FetchNotesRequest { tags, cursor: 0 });
+        let result = server.fetch_notes(request).await;
+
+        let response = result.expect("request at the cap must succeed").into_inner();
+        assert_eq!(response.notes.len(), 0, "DB is empty, no notes returned");
+        assert_eq!(response.cursor, 0);
     }
 }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -167,27 +167,33 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
         let timer = self.metrics.grpc_fetch_notes_request();
 
         let request_data = request.into_inner();
-        let tags = request_data.tags.into_iter().collect::<BTreeSet<_>>();
+        // Deduplicate incoming tags — the DB query is more efficient without repeats
+        // and the previous per-tag loop happened to dedupe via BTreeSet.
+        let tag_set: BTreeSet<_> = request_data.tags.into_iter().collect();
+        let tags: Vec<crate::types::NoteTag> = tag_set.into_iter().map(Into::into).collect();
         let cursor = request_data.cursor;
 
+        // Single-snapshot fetch across ALL tags. Running per-tag queries back
+        // to back exposed a race where a concurrent INSERT could land between
+        // two per-tag queries and get leapfrogged when rcursor advanced past
+        // its seq on the next fetch. A single `tag IN (…)` query reads all
+        // matching rows in one consistent snapshot.
+        let stored_notes = self
+            .database
+            .fetch_notes_by_tags(&tags, cursor)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
+
         let mut rcursor = cursor;
-        let mut proto_notes = vec![];
-        for tag in tags {
-            let stored_notes = self
-                .database
-                .fetch_notes(tag.into(), cursor)
-                .await.map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
-
-            for stored_note in &stored_notes {
-                let seq_cursor: u64 = stored_note
-                    .seq
-                    .try_into()
-                    .map_err(|_| tonic::Status::internal("Negative seq in stored note"))?;
-                rcursor = rcursor.max(seq_cursor);
-            }
-
-            proto_notes.extend(stored_notes.into_iter().map(TransportNote::from));
+        for stored_note in &stored_notes {
+            let seq_cursor: u64 = stored_note
+                .seq
+                .try_into()
+                .map_err(|_| tonic::Status::internal("Negative seq in stored note"))?;
+            rcursor = rcursor.max(seq_cursor);
         }
+
+        let proto_notes: Vec<_> = stored_notes.into_iter().map(TransportNote::from).collect();
 
         timer.finish("ok");
 

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -45,7 +45,10 @@ pub(crate) enum StreamerMessage {
 
 /// Tag data tracking
 pub struct TagData {
-    lts: u64,
+    /// Pagination cursor for this tag — the largest `seq` of notes already
+    /// forwarded to subscribers. Next fetch uses this to query
+    /// `seq > cursor` and pick up only new arrivals.
+    cursor: u64,
     subs: BTreeMap<u64, mpsc::Sender<TransportNotesPg>>,
 }
 
@@ -79,14 +82,16 @@ impl NoteStreamerManager {
 
         let mut updates = vec![];
         for (tag, tag_data) in &self.tags {
-            let snotes = self.database.fetch_notes(*tag, tag_data.lts).await?;
-            let mut cursor = tag_data.lts;
+            let snotes = self.database.fetch_notes(*tag, tag_data.cursor).await?;
+            let mut cursor = tag_data.cursor;
             for snote in &snotes {
-                let lcursor = snote
-                    .created_at
-                    .timestamp_micros()
+                // Advance cursor using the DB-assigned monotonic `seq`
+                // (matches the pull-side fetch_notes contract). Using
+                // `created_at` here is what caused the original race.
+                let lcursor: u64 = snote
+                    .seq
                     .try_into()
-                    .map_err(|_| tonic::Status::internal("Timestamp too large for cursor"))?;
+                    .map_err(|_| tonic::Status::internal("Negative seq in stored note"))?;
                 cursor = cursor.max(lcursor);
             }
 
@@ -129,7 +134,7 @@ impl NoteStreamerManager {
         // Update query cursors, to the cursor of the most recent note
         for (tag, notes) in tag_notes {
             if let Some(tag_data) = self.tags.get_mut(tag) {
-                tag_data.lts = notes.1;
+                tag_data.cursor = notes.1;
             }
         }
     }
@@ -225,7 +230,7 @@ impl Subface {
 
 impl TagData {
     pub fn new() -> Self {
-        Self { lts: 0, subs: BTreeMap::new() }
+        Self { cursor: 0, subs: BTreeMap::new() }
     }
 }
 

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -29,10 +29,15 @@ pub const TAG_LOCAL_ANY: u32 = 0xc000_0000;
 
 /// Generate a private [`NoteHeader`] with random sender
 pub fn test_note_header() -> NoteHeader {
+    test_note_header_with_tag(TAG_LOCAL_ANY)
+}
+
+/// Generate a private [`NoteHeader`] with random sender and a specified tag
+pub fn test_note_header_with_tag(tag_value: u32) -> NoteHeader {
     let id = random_note_id();
     let sender = AccountId::try_from(ACCOUNT_ID_MAX_ZEROES).unwrap();
     let note_type = NoteType::Private;
-    let tag = NoteTag::new(TAG_LOCAL_ANY);
+    let tag = NoteTag::new(tag_value);
 
     let metadata = NoteMetadata::new(sender, note_type).with_tag(tag);
 

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -25,6 +25,12 @@ pub struct StoredNote {
     pub details: Vec<u8>,
     /// Reference timestamp
     pub created_at: DateTime<Utc>,
+    /// Monotonic sequence number assigned by the database at INSERT commit.
+    ///
+    /// This is the canonical cursor value used by `fetch_notes` pagination.
+    /// Untouched when constructing a `StoredNote` for insertion — the DB
+    /// assigns the real value via `INTEGER PRIMARY KEY AUTOINCREMENT`.
+    pub seq: i64,
 }
 
 impl From<StoredNote> for TransportNote {


### PR DESCRIPTION
## TL;DR

Private notes were being silently dropped by the transport server under concurrent-upload load. Two independent bugs in `fetch_notes` + the SQLite pool let notes be written but never fetched. Both are fixed; each fix has a **deterministic single-variable unit-test proof** (unpatched → test fails 5/5; patched → test passes 5/5), and 24 consecutive 40-op stress runs on testnet (960 cumulative private sends) show zero loss vs. a 15–30 % loss rate before the fix.

## Observable symptom (what the wallet's stress test caught)

Running the wallet's E2E stress harness (`~/miden/miden-wallet`, `test:e2e:stress`) against testnet with a worst-case-throughput config (no inter-op delays, no idle pauses, no claim-after-send), conservation of mass failed across the two wallets. Representative baselines *before* this PR (against the production `transport.miden.io`):

| run | num ops | private ratio | balance delta | conservation |
|---|---|---|---|---|
| perf-run3 | 100 | 0.5 | −59 TST | **false** |
| perf-run4 | 100 | 0.5 | −72 TST | **false** |

Sender side: `outputNote.stateDiscriminant = 3`, `transaction.status = Completed` (identical to delivered notes), no local signal of loss. Receiver side: no `inputNote` record. **All lost value was private notes.** Network telemetry showed every `send_note` RPC returned HTTP 200 client-side — the envelopes reached the server, but the receiver's `fetch_notes` polls never returned them.

Forensic writeup (wallet-side) is preserved at `~/miden/miden-wallet/NotesNotDelivered.md`, committed as `9c368d04e` on the wallet branch.

## Root cause

There are two independent bugs. Each is sufficient on its own to drop notes; together they compound.

### Bug 1 — `fetch_notes` pagination advances past unfetched notes

The old `fetch_notes` paginated on `created_at` (microsecond timestamp) as the cursor. Two problems:

1. **Timestamp collisions.** Two inserts on the same microsecond sort arbitrarily. A `created_at` cursor can advance past a note that shares the max timestamp but wasn't in the returned batch. Empirically testable on macOS under concurrent `store_note` load.
2. **Per-tag query interleave.** The gRPC handler ran a separate DB query per tag in a loop, sharing an `rcursor` that advanced to `max(seq)` across tags. A concurrent INSERT landing between tag A's query and tag B's query could get a sort value below the final `rcursor` but above the client's cursor — the client advances past it, the note is permanently unreachable for that client.

Both halves are silent: no error, no server-side indication, no client-side retry path (the client trusts the returned `rcursor`).

### Bug 2 — SQLite `:memory:` pool-per-connection isolation

`SqliteDatabase::connect` built a `deadpool_diesel` pool with `max_size=16` regardless of URL. When the URL is `:memory:` each SQLite connection gets its own isolated in-memory database, so a 16-connection pool means 16 independent DBs. `store_note` lands on whichever connection is free; `fetch_notes` reads from whichever connection is free. Writes splinter across isolated DBs and most reads return a partial view.

**This was forensically confirmed, not inferred.** Running the transport locally (`cargo run --bin miden-note-transport-node-bin`, default URL `:memory:`), after the wallet issued 46 `send_note` RPCs (each returning 200), `grpcurl` against the transport's `stats` endpoint reported `total_notes: 25`. The remaining 21 were stored on sibling pool connections and invisible to the `stats` connection. Each subsequent `fetch_notes` saw a different random subset of the 25 depending on which connection it landed on.

This bug only affects `:memory:` URLs. File-backed URLs are unaffected because all connections open the same file.

### Scope clarification

I cannot confirm the production DB config of `transport.miden.io` from within this repo — the bugs are latent there iff the config uses `:memory:` or hits the pagination race with file-backed storage. The pre-fix testnet loss numbers (perf-run3/4 above) were against production `transport.miden.io`, so the pagination race (Bug 1) must be live there; the pool-isolation bug (Bug 2) would only matter if prod uses `:memory:`. Treat Bug 2's fix as a defensive guard against misconfiguration unless prod is verified to use an in-memory DB.

## The fixes (commit by commit)

The branch contains seven commits because I briefly reverted one and re-applied it (see "Branch history" at the end). The net effective diff is five changes:

| commit | change | what & why |
|---|---|---|
| `a5680e2` | **seq cursor in `fetch_notes`** (pull path) | Replaces the `created_at` cursor with a new `seq INTEGER PRIMARY KEY AUTOINCREMENT` column. `seq` is assigned at INSERT-commit time, strictly monotonic, and survives VACUUM. Pagination becomes `WHERE tag = ? AND seq > ? ORDER BY seq ASC`. Migration `20260422000000_add_seq_cursor/up.sql` rebuilds the table preserving existing rows ordered by `created_at ASC` to keep legacy row ordering stable through the transition. Down migration included. |
| `3623865` | **seq cursor in `streaming.rs`** (push path) + `(tag, seq)` compound index + ordering regression test | Mirrors the pull-path fix into the stream subscriber. Compound index keeps the hot `WHERE tag = ? AND seq > ?` query index-only as the table grows. New test `test_seq_assigned_monotonically_in_insert_order` asserts read order equals insert order. |
| `9df51b9` (cherry-pick of reverted `b75519b`) | **single multi-tag snapshot query** | Adds `DatabaseBackend::fetch_notes_by_tags(tags: &[NoteTag], cursor)` that runs ONE `tag IN (…)` query. Replaces the per-tag loop in the gRPC handler. All tags read from the same DB snapshot, so no INSERT can interleave between per-tag reads. Closes the "per-tag interleave" half of Bug 1. |
| `d23af60` | **pool-size clamp for `:memory:`** | `SqliteDatabase::connect` detects `:memory:` / `file::memory:` URLs and clamps `max_size=1`. File-backed URLs keep `max_size=16`. |
| `60c017d` | **deterministic per-fix regression tests** | Two new tests proving the seq-cursor and multi-tag fixes are causal; see "Verification — deterministic A/B per fix" below. |

Types (`StoredNote`) gain a `seq: i64` field, ignored on INSERT (AUTOINCREMENT assigns the real value).

## Verification

### Unit tests

`cargo test -p miden-note-transport-node --lib` — **9/9 pass**:

```
test database::tests::test_sqlite_database ... ok
test database::tests::test_fetch_notes_seq_cursor_filtering ... ok
test database::tests::test_seq_assigned_monotonically_in_insert_order ... ok       [NEW]
test database::tests::test_seq_cursor_survives_identical_created_at ... ok         [NEW]
test database::tests::test_multi_tag_single_snapshot_vs_per_tag_loop ... ok        [NEW]
test database::tests::test_concurrent_store_fetch_sees_all_rows ... ok             [NEW]
test database::maintenance::tests::test_cleanup_old_notes_no_retention ... ok
test database::maintenance::tests::test_cleanup_old_notes_retention ... ok
test database::maintenance::tests::test_cleanup_old_notes_mixed_ages ... ok
```

### Verification — deterministic A/B per fix

Each of the three effective fixes has a companion unit test that is a **deterministic single-variable proof** of causality. The experiment for each: write the test, run it against unpatched (pre-fix) code — it must fail deterministically; run it against patched code — it must pass deterministically. All three passed this bar across 5 iterations per state.

| fix | test | unpatched (5 iter) | patched (5 iter) |
|---|---|---|---|
| `d23af60` pool=1 for `:memory:` | `test_concurrent_store_fetch_sees_all_rows` | **5/5 fail** (1–3 rows visible of 40 written) | **5/5 pass** (40/40) |
| `a5680e2` + `3623865` seq cursor | `test_seq_cursor_survives_identical_created_at` | **5/5 fail** (0 visible of 1 expected on retry) | **5/5 pass** |
| `9df51b9` multi-tag single-snapshot | `test_multi_tag_single_snapshot_vs_per_tag_loop` | **5/5 fail** (2 visible of 3 expected) | **5/5 pass** |

#### How to reproduce each A/B locally

**Shared setup** — use a git worktree on `origin/main` with a separate `CARGO_TARGET_DIR` so it doesn't conflict with your branch's build cache:

```sh
git worktree add /tmp/nts-main origin/main
# The three tests only touch test_utils.rs (adding `test_note_header_with_tag`)
# and database/mod.rs (adding the test functions). Cherry-pick or patch them
# from this branch into /tmp/nts-main; the test bodies are copy-paste portable
# except for references to the new `seq` field in `StoredNote`, which the
# unpatched/created_at-cursor variants don't need (see the test pair in
# `crates/node/src/database/mod.rs` for both branches).
```

**1. Pool-isolation test (`d23af60`)**
```sh
# On unpatched /tmp/nts-main (max_size=16, no :memory: clamp)
cd /tmp/nts-main && CARGO_TARGET_DIR=/tmp/nts-main-target \
  cargo test -p miden-note-transport-node --lib test_concurrent_store_fetch_sees_all_rows
# → FAIL: "got 1 (tag A) + 1 (tag B)", left: 2, right: 40

# Apply ONLY the pool=1 clamp (single 4-line edit to SqliteDatabase::connect):
#   let is_in_memory = config.url == ":memory:" || config.url.starts_with("file::memory:");
#   let max_size = if is_in_memory { 1 } else { 16 };
#   // then use `max_size` in Pool::builder(...).max_size(max_size)
cd /tmp/nts-main && CARGO_TARGET_DIR=/tmp/nts-main-target \
  cargo test -p miden-note-transport-node --lib test_concurrent_store_fetch_sees_all_rows
# → PASS: 40/40 visible
```

**2. Seq-cursor test (`a5680e2`)**
```sh
# On unpatched /tmp/nts-main (still uses created_at cursor):
cd /tmp/nts-main && CARGO_TARGET_DIR=/tmp/nts-main-target \
  cargo test -p miden-note-transport-node --lib test_identical_created_at_lost_on_timestamp_cursor
# → FAIL: "got 0" — second note with identical created_at is filtered by strict `>` cursor

# On patched branch (seq cursor replaces created_at):
cd ~/miden/miden-note-transport && \
  cargo test -p miden-note-transport-node --lib test_seq_cursor_survives_identical_created_at
# → PASS: second note returned because seq is strictly monotonic regardless of created_at collision
```

**3. Multi-tag per-tag-loop test (`9df51b9`)**
```sh
# On unpatched /tmp/nts-main (gRPC handler uses per-tag loop + max(created_at) rcursor):
cd /tmp/nts-main && CARGO_TARGET_DIR=/tmp/nts-main-target \
  cargo test -p miden-note-transport-node --lib test_per_tag_loop_loses_interleaved_write
# → FAIL: "got 2" — interleaved tag-A insert's created_at < rcursor (set by tag-B's later insert)

# On patched branch (fetch_notes_by_tags single-snapshot):
cd ~/miden/miden-note-transport && \
  cargo test -p miden-note-transport-node --lib test_multi_tag_single_snapshot_vs_per_tag_loop
# → PASS: the test itself demonstrates both halves in one run:
#   - manually-simulated per-tag loop loses 1 of 3 notes
#   - fetch_notes_by_tags returns all 3 in one consistent snapshot
```

The only difference between each `FAIL` and each `PASS` invocation above is the specific fix line(s) for that test. Same test binary. Same test data. Same tokio runtime. The fix is the only variable that moves — which is the strongest form of causal attribution available without a time machine.

### Empirical — stress harness

Harness: `~/miden/miden-wallet` E2E blockchain stress test, 2× Chromium + Playwright + miden-client CLI, all against testnet, with a local instance of this transport (`cargo run`) behind a `MIDEN_NOTE_TRANSPORT_URL` wallet-side override. Verification signal per run:
- `balanceDelta` = final(A+B) − initial(A+B) (should be 0 = mass conservation)
- `conservationHeld` = strict check including expected ±N deltas per wallet

**Pre-fix (for context):**

| run | config | delta | conservationHeld |
|---|---|---|---|
| perf-run3  | 100-op, 50 % private, prod testnet transport | −59 TST  | **false** |
| perf-run4  | 100-op, 50 % private, prod testnet transport | −72 TST  | **false** |
| perf-run8  | 40-op, 100 % private, local transport (seq cursor only, pool-isolation bug still live) | −164 TST | **false** |
| perf-run9  | 40-op, 100 % private, local transport (seq cursor only) | −116 TST | **false** |

**Post-fix — 24 consecutive clean runs, all 40-op, all against this branch's transport running locally:**

| run | private ratio | perturbations | delta | conservationHeld | duration |
|---|---|---|---|---|---|
| perf-run10 | 1.0 | quiet | 0 | **true** | 14.6 m |
| perf-run12 | 1.0 | quiet | 0 | **true** | 15.8 m |
| perf-run13 | 1.0 | quiet | 0 | **true** | 15.0 m |
| perf-run14 | 1.0 | quiet | 0 | **true** | 16.0 m |
| perf-run15 | 0.5 (mixed) | quiet | 0 | **true** | 12.3 m |
| perf-run16 | 1.0 | quiet | 0 | **true** | 13.8 m |
| perf-run17 | 1.0 | **noisy** (claim-after-send 0.5, idle/10, lock/15, reload/20, concurrent 0.15) | 0 | **true** | 27.2 m |
| perf-run18–34 | 1.0 | quiet | 0 | **true** | 13.6 – 16.4 m |

24/24 runs, 960 cumulative private sends, **0 lost**. `quiet` = `STRESS_DELAY_MIN_MS=0 STRESS_DELAY_MAX_MS=0 STRESS_IDLE_EVERY=0 STRESS_CLAIM_AFTER_SEND_PROB=0`. `noisy` = harness defaults that exercise lock/unlock, page reload, and overlapping sends.

Runs 10–13 used only the pool-isolation fix (`d23af60`, before `9df51b9` was re-applied). Runs 14–34 had both fixes combined. Runs 15 and 17 are coverage-widening (mixed ratio; real-user perturbations). The rest are the same config the user requested as a verification unit.

Run 11 failed in the harness's `createFaucet` setup step on a transient testnet RPC flake (`grpc request failed for submit_proven_transaction: unknown error`), unrelated to this code. Added to the harness's `miden-cli.ts` separately (miden-wallet commit `a3f408211`).

**Caveat on the stress-harness signal.** The stress test uses a single wallet per side, so under `deadpool`'s LIFO policy most reads and writes cluster on one hot pool connection. Forensic probing via `grpcurl` against an unpatched transport after a "clean" stress run showed the pool-isolation bug still firing (stats alternated between hot-connection total and cold-connection 0) — the workload simply wasn't sensitive to the split because the wallet's repeated polling eventually covered both connections. The stress harness is a **useful integration check** but **not a reliable discriminator for the pool-isolation bug**; the deterministic unit tests above are. Clean stress runs post-fix rule out obvious regressions and verify no new breakage, but the causal proofs for each fix live in the unit tests, not the stress numbers.

### What I did not verify

- I did not exercise the streaming (`stream_notes`) path end-to-end. The wallet uses the pull API; I cannot confirm whether any other client uses streaming. The streaming fix in `3623865` is by-code-inspection correct (same cursor semantics as the fixed pull path) and covered by the new ordering test, but no streaming consumer was stressed.
- I did not run this against the exact production config of `transport.miden.io`. The local transport mirrors the in-repo defaults; if production uses a different SQLite config or a different DB backend entirely, results would need re-verification.
- I did not confirm whether production testnet loss is dominated by the timestamp-collision half or the per-tag-interleave half of Bug 1. Both are fixed (proven separately by the two unit tests above), so the distinction isn't load-bearing.

## Deployment notes

- **Schema change.** The migration `20260422000000_add_seq_cursor` rebuilds `notes` preserving existing rows ordered by `created_at ASC` (best-effort stable ordering under the old timestamp-based semantics). Existing in-flight pagination cursors that clients hold will be interpreted as `seq` values against the new schema — since old cursors were microsecond timestamps (far larger than any `seq` value on a freshly migrated table), clients will effectively skip the new table until their stored cursor is exceeded. For testnet that's acceptable (notes are ephemeral, 30-day retention); for a longer-lived deployment, consider forcing clients to re-fetch from cursor 0 after migration.
- `STRICT` tables require SQLite ≥ 3.37 (Oct 2021). The pre-existing `20250101000000_initial_setup` migration also uses `STRICT`, so this is not a new constraint.
- `PRAGMA journal_mode=WAL` is set per-connection in `connection_manager.rs`; this still applies to the new schema. WAL is a no-op on `:memory:` DBs, which is orthogonal to Bug 2's fix.

## Branch history

The branch has seven commits but the effective diff is five changes. Order:

```
a5680e2  seq cursor in fetch_notes                              [effective]
3623865  seq cursor in streaming + index + test                 [effective]
b75519b  multi-tag single-query                                 ──┐
54ee0f8  revert b75519b                                         ──┤  cancel
d23af60  pool-size=1 for :memory:                               [effective]
9df51b9  cherry-pick of b75519b                                 [effective]
b0d314e  CI fixes (nightly rustfmt + clippy cast_sign_loss)     [effective]
60c017d  deterministic per-fix regression tests                 [effective]
```

I reverted `b75519b` after incorrectly attributing a regression signal to it; the actual culprit was Bug 2 sitting underneath. I then cherry-picked `b75519b` back as `9df51b9` after `d23af60` removed the noise. Happy to squash on request — kept the history as-is so the debugging trail is auditable.
