### PR TITLE
fix(ci): green the dependency-audit job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.7"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae09a41a4b89f94ec1e053623da8340d996bc32c6517d325a9daad9b239358"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bigdecimal",
  "diesel_derives",
@@ -1680,7 +1680,7 @@ dependencies = [
  "p3-miden-lifted-stark",
  "p3-symmetric",
  "p3-util",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
@@ -1815,7 +1815,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serial_test",
  "thiserror",
  "tokio",
@@ -1932,7 +1932,7 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xoshiro",
  "regex",
@@ -2306,7 +2306,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2822,7 +2822,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3012,9 +3012,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/deny.toml
+++ b/deny.toml
@@ -44,8 +44,6 @@ allow = [
   "ISC",
   "JSON",
   "MIT",
-  # Weak (file-level) copyleft, used only by build-time deps of the miden stack
-  # (pubgrub, version-ranges, priority-queue via miden-package-registry).
   "MPL-2.0",
   "MS-PL",
   "OpenSSL",

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,9 @@ allow = [
   "ISC",
   "JSON",
   "MIT",
+  # Weak (file-level) copyleft, used only by build-time deps of the miden stack
+  # (pubgrub, version-ranges, priority-queue via miden-package-registry).
+  "MPL-2.0",
   "MS-PL",
   "OpenSSL",
   "PostgreSQL",


### PR DESCRIPTION
## Summary

The `dependency-audit` (cargo-deny) CI job has been failing on `main` since 2026-04-08 (last green: 2026-04-04). The failure is unrelated to application code - it is a mix of a license-policy gap and dependency advisories. This PR makes the job green again.

## Causes and fixes

- License rejections: `pubgrub` and `version-ranges` are `MPL-2.0`; `priority-queue` is `LGPL-3.0-or-later OR MPL-2.0`. All are pulled in transitively as build-time deps of the miden stack via `miden-package-registry`. Fix: allow `MPL-2.0` in `deny.toml` (weak, file-level copyleft; the `OR` clause covers `priority-queue`).
- [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`rand` <0.9.3, unsound with a custom logger calling `rand::rng()`). Fix: bump `rand` 0.9.2 -> 0.9.4.
- [RUSTSEC-2026-0111](https://rustsec.org/advisories/RUSTSEC-2026-0111.html) / [0134](https://rustsec.org/advisories/RUSTSEC-2026-0134.html) / [0135](https://rustsec.org/advisories/RUSTSEC-2026-0135.html) / [0136](https://rustsec.org/advisories/RUSTSEC-2026-0136.html) / [0137](https://rustsec.org/advisories/RUSTSEC-2026-0137.html) (`diesel` <2.3.8 SQLite/MySQL/Postgres soundness and `COPY` command injection). Fix: bump `diesel` 2.3.7 -> 2.3.9.

All advisory bumps are patch-level updates within the existing `Cargo.toml` version ranges, so no manifest changes are needed beyond the lockfile.

## Verification

`cargo deny check` locally:

```
advisories ok, bans ok, licenses ok, sources ok
```

Split out from the `miden-protocol` 0.15 bump (#88) to keep that PR a clean dependency bump and to restore the audit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)