### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node-bin"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "miden-note-transport-node",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "fs-err",
  "miette",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-note-transport"
 rust-version = "1.87"
-version      = "0.3.2"
+version      = "0.4.0"
 
 [workspace.dependencies]
 # Workspace crates (path-based dependencies)
-miden-note-transport-node        = { path = "crates/node", version = "0.3.2" }
-miden-note-transport-proto       = { path = "crates/proto", version = "0.3.2" }
-miden-note-transport-proto-build = { path = "proto", version = "0.3.2" }
+miden-note-transport-node        = { path = "crates/node", version = "0.4.0" }
+miden-note-transport-proto       = { path = "crates/proto", version = "0.4.0" }
+miden-note-transport-proto-build = { path = "proto", version = "0.4.0" }
 
 # miden-base aka protocol dependencies (git = "https://github.com/0xMiden/miden-base"). These should be updated in sync.
 miden-protocol = { default-features = false, version = "0.15" }


### PR DESCRIPTION
Bumps the workspace version from `0.3.2` to `0.4.0`.

## Changes

- `Cargo.toml`: package `version` and the three internal path-dependency version pins (`miden-note-transport-node`, `miden-note-transport-proto`, `miden-note-transport-proto-build`) updated to `0.4.0`.
- `Cargo.lock`: regenerated so all four workspace crates resolve at `0.4.0`.

The `## v0.4.0 (unreleased)` section already exists in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)