### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Skip the changelog only when the PR contains no runtime-affecting changes
 
 ### Changes
 
-- [BREAKING] Switched OpenTelemetry configuration to `--enable-otel`/`--otel-endpoint` flags and standard `OTEL_EXPORTER_OTLP_*` env vars, replacing `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
+- Changed OpenTelemetry configuration: enable via `--enable-otel`/`--otel-endpoint` flags or the standard `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env vars. The previous `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` vars are no longer read ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
 
 ## v0.4.0 (2026-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,20 @@ Skip the changelog only when the PR contains no runtime-affecting changes
 (docs, CI, tooling, tests). In that case the hook will tell you to apply the
 `no changelog` label instead.
 
-## v0.4.0 (unreleased)
+## v0.4.1 (2026-06-17)
 
 ### Features
 
+- Added optional `after_block_num` to `TransportNote` so senders can give recipients a deterministic block floor for commitment scans ([#81](https://github.com/0xMiden/note-transport-service/pull/81)).
+- Added structured tracing fields across the gRPC, database, and streaming layers for debuggability ([#83](https://github.com/0xMiden/note-transport-service/pull/83)).
+
 ### Changes
 
-### Fixes
+- [BREAKING] Switched OpenTelemetry configuration to `--enable-otel`/`--otel-endpoint` flags and standard `OTEL_EXPORTER_OTLP_*` env vars, replacing `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
+
+## v0.4.0 (2026-06-08)
+
+Released without itemized changelog entries. See [`git log v0.3.2..v0.4.0`](https://github.com/0xMiden/note-transport-service/compare/v0.3.2...v0.4.0) for the change set.
 
 ## v0.3.1 (2026-04-08)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node-bin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "miden-note-transport-node",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fs-err",
  "miette",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-note-transport"
 rust-version = "1.87"
-version      = "0.4.0"
+version      = "0.4.1"
 
 [workspace.dependencies]
 # Workspace crates (path-based dependencies)
-miden-note-transport-node        = { path = "crates/node", version = "0.4.0" }
-miden-note-transport-proto       = { path = "crates/proto", version = "0.4.0" }
-miden-note-transport-proto-build = { path = "proto", version = "0.4.0" }
+miden-note-transport-node        = { path = "crates/node", version = "0.4.1" }
+miden-note-transport-proto       = { path = "crates/proto", version = "0.4.1" }
+miden-note-transport-proto-build = { path = "proto", version = "0.4.1" }
 
 # miden-base aka protocol dependencies (git = "https://github.com/0xMiden/miden-base"). These should be updated in sync.
 miden-protocol = { default-features = false, version = "0.15" }


### PR DESCRIPTION
## Summary

Release v0.4.1 — version bump + changelog for the changes merged since v0.4.0.

- Bumped workspace version `0.4.0` -> `0.4.1` (`Cargo.toml` + `Cargo.lock`).
- Added `CHANGELOG.md` entries (one line per PR):
  - Added `after_block_num` to `TransportNote` for deterministic commitment-scan floors ([#81](https://github.com/0xMiden/note-transport-service/pull/81)).
  - Added structured tracing fields across gRPC/DB/streaming ([#83](https://github.com/0xMiden/note-transport-service/pull/83)).
  - Changed OpenTelemetry configuration to flags / standard `OTEL_EXPORTER_OTLP_*` env vars ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
- Dated the previously stale `v0.4.0 (unreleased)` changelog header (0.4.0 shipped 2026-06-08) with a git-compare reference.

## Note for operators

The OTel env var names changed in #80: `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` are no longer read; use `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or the new `--enable-otel`/`--otel-endpoint` flags.

## Release step (after merge)

Create a GitHub Release with tag `v0.4.1` at `main` HEAD, which triggers the crates.io publish workflow. Not done in this PR.
