### PR TITLE
feat: improve Docker Compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,15 @@ build: ## Builds all crates and re-builds protobuf bindings for proto crates
 # --- node-docker ---------------------------------------------------------------------------------
 
 .PHONY: docker-node-up
-docker-node-up:
+docker-node-up: ## Starts up the local Docker compose environment
 	docker-compose -f bin/node/docker/docker-compose.yml --project-directory . up -d
 
 .PHONY: docker-node-down
-docker-node-down:
+docker-node-down: ## Stops the local Docker compose environment
 	docker-compose -f bin/node/docker/docker-compose.yml --project-directory . down
 
 .PHONY: docker-node-restart
-docker-node-restart:
+docker-node-restart: ## Restarts the local Docker compose environment
 	docker-compose -f bin/node/docker/docker-compose.yml --project-directory . restart
 
 

--- a/bin/node/docker/Dockerfile
+++ b/bin/node/docker/Dockerfile
@@ -1,7 +1,5 @@
 # Miden Note Transport Node
-FROM rust:1.90-slim-bookworm as builder
-
-
+FROM rust:1.90-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -24,7 +22,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-    sqlite3 \
+    sqlite3 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/cargo/bin/miden-note-transport-node-bin /usr/local/bin/miden-note-transport-node-bin

--- a/bin/node/docker/docker-compose.yml
+++ b/bin/node/docker/docker-compose.yml
@@ -5,8 +5,15 @@ services:
       context: .
       dockerfile: bin/node/docker/Dockerfile
     ports:
-      - "57292:57292"  # gRPC
-    command: ["miden-note-transport-node-bin", "--host", "0.0.0.0", "--database-url", "/app/data/node.db"]
+      - "57292:57292" # gRPC
+    command:
+      [
+        "miden-note-transport-node-bin",
+        "--host",
+        "0.0.0.0",
+        "--database-url",
+        "/app/data/node.db",
+      ]
     environment:
       - JSON_LOGGING=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
@@ -27,11 +34,10 @@ services:
     volumes:
       - ./bin/node/docker/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "4317:4317"     # OTLP gRPC receiver (apps send traces here)
-      - "4318:4318"     # OTLP HTTP receiver
-      - "13133:13133"   # Health check
-      - "1777:1777"     # pprof
-      - "9464:9464"     # Prometheus metrics
+      - "4317:4317" # OTLP gRPC receiver (apps send traces here)
+      - "13133:13133" # Health check
+      - "1777:1777" # pprof
+      - "9464:9464" # Prometheus metrics
     depends_on:
       - tempo
     networks:
@@ -39,12 +45,12 @@ services:
 
   # Traces
   tempo:
-    image: grafana/tempo:latest
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    image: grafana/tempo:2.10.4
+    command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./bin/node/docker/tempo.yaml:/etc/tempo.yaml:ro
     ports:
-      - "3200:3200"   # tempo
+      - "3200:3200" # tempo
     networks:
       - telemetry
 
@@ -65,19 +71,20 @@ services:
 
   # Visualization
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
+      - ./bin/node/docker/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - grafana_data:/var/lib/grafana
     networks:
       - telemetry
     depends_on:
       - tempo
-
 
 volumes:
   grafana_data:

--- a/bin/node/docker/grafana/datasources.yaml
+++ b/bin/node/docker/grafana/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: true
+    version: 1
+    editable: false
+    uid: tempo

--- a/bin/node/docker/otel-collector-config.yaml
+++ b/bin/node/docker/otel-collector-config.yaml
@@ -3,8 +3,6 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
 
 processors:
   batch: {}

--- a/bin/node/docker/prometheus.yml
+++ b/bin/node/docker/prometheus.yml
@@ -2,6 +2,6 @@ global:
   scrape_interval: 5s
 
 scrape_configs:
-  - job_name: 'otel-collector'
+  - job_name: "otel-collector"
     static_configs:
-      - targets: ['otel-collector:9464']
+      - targets: ["otel-collector:9464"]

--- a/bin/node/docker/tempo.yaml
+++ b/bin/node/docker/tempo.yaml
@@ -1,3 +1,5 @@
+stream_over_http_enabled: true
+
 server:
   http_listen_port: 3200
 
@@ -6,26 +8,24 @@ distributor:
     otlp:
       protocols:
         grpc:
-          endpoint: 0.0.0.0:4317
-        http:
-          endpoint: 0.0.0.0:4318
-
-ingester:
-  max_block_bytes: 100_000_000
-  max_block_duration: 5m
-
-compactor:
-  compaction:
-    block_retention: 1h
+          endpoint: "0.0.0.0:4317"
 
 storage:
   trace:
     backend: local
     local:
-      path: /tmp/tempo/blocks
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
 
 metrics_generator:
   registry:
     external_labels:
       source: tempo
-      cluster: docker-compose
+  storage:
+    path: /var/tempo/metrics/wal
+  traces_storage:
+    path: /var/tempo/metrics/traces
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator


### PR DESCRIPTION
This PR improves the local Docker compose environment for the note transport node by making observability services reproducible, auto-provisioning Grafana datasources, updating Tempo config for the pinned image, and fixing TLS certificate support in the runtime container.

### Detailed Description

This branch updates the local Docker setup used by make docker-node-up and related targets.

Changes include:

  - Pins observability image versions. Otherwise major versions upgrades might break compatibility with our configuration files:
      - `grafana/grafana:12.4`
      - `grafana/tempo:2.10.4`

  - Adds Grafana datasource provisioning so Prometheus and Tempo are available automatically on startup.
  - Enables anonymous Grafana admin access for the local compose environment, avoiding manual login setup.
  - Updates Tempo configuration for the pinned Tempo version:
      - Enables service graph, span metrics, and local block processors. These are required for the Grafana trace drill-down page to work.

  - Removes unused OTLP HTTP receiver exposure from the OpenTelemetry collector setup, keeping OTLP gRPC as the configured ingest path.
  - Adds `ca-certificates` to the runtime Docker image so the node container can make TLS-backed outbound requests reliably.
  - Adds Makefile help descriptions for Docker-related make targets so that they show up in `make help`:
      - `docker-node-up`
      - `docker-node-down`
      - `docker-node-restart`

With these changes we get useful trace drill-downs out-of-the-box in the Grafana instance listening on http://localhost:3000/:

<img width="3341" height="1466" alt="image" src="https://github.com/user-attachments/assets/1654c7ac-f82c-47aa-bf61-dc120356233e" />
