### PR TITLE
fix: reset fetch_notes cursor stranded above the seq high-water

### DIFF
--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -34,11 +34,17 @@ pub trait DatabaseBackend: Send + Sync {
     /// This is the preferred multi-tag query — running per-tag queries back
     /// to back reopens a race where a concurrent INSERT can land between two
     /// per-tag queries and get leapfrogged by the cursor advance.
+    ///
+    /// Returns the matching notes and the *effective* cursor used for the
+    /// `seq > ?` filter — 0 if the requested cursor was reset (legacy µs cursor,
+    /// or stranded above the seq high-water), otherwise the requested cursor.
+    /// Callers should base their response cursor on this effective value so a
+    /// reset heals the client rather than re-triggering every poll.
     async fn fetch_notes_by_tags(
         &self,
         tags: &[NoteTag],
         cursor: u64,
-    ) -> Result<Vec<StoredNote>, DatabaseError>;
+    ) -> Result<(Vec<StoredNote>, u64), DatabaseError>;
 
     /// Get statistics about the database
     async fn get_stats(&self) -> Result<(u64, u64), DatabaseError>;
@@ -99,11 +105,14 @@ impl Database {
     }
 
     /// Fetch notes matching ANY of a set of tags, in a single DB snapshot.
+    ///
+    /// Returns the notes plus the effective cursor used (see
+    /// [`DatabaseBackend::fetch_notes_by_tags`]).
     pub async fn fetch_notes_by_tags(
         &self,
         tags: &[NoteTag],
         cursor: u64,
-    ) -> Result<Vec<StoredNote>, DatabaseError> {
+    ) -> Result<(Vec<StoredNote>, u64), DatabaseError> {
         self.backend.fetch_notes_by_tags(tags, cursor).await
     }
 
@@ -430,7 +439,7 @@ mod tests {
         );
 
         // === The fix: single-snapshot multi-tag query ===
-        let snapshot = db.fetch_notes_by_tags(&[TAG_A.into(), TAG_B.into()], 0).await.unwrap();
+        let (snapshot, _) = db.fetch_notes_by_tags(&[TAG_A.into(), TAG_B.into()], 0).await.unwrap();
         assert_eq!(
             snapshot.len(),
             3,
@@ -472,10 +481,68 @@ mod tests {
             "legacy microsecond cursor should be reset to 0, returning the note"
         );
 
-        // Sanity check: a non-legacy cursor above the note's seq should NOT trigger the reset.
-        let normal_cursor: u64 = 1_000;
-        let empty = db.fetch_notes(TAG_LOCAL_ANY.into(), normal_cursor).await.unwrap();
-        assert_eq!(empty.len(), 0, "normal cursor > seq should filter correctly");
+        // Sanity check: a caught-up client's cursor (== the note's own seq, i.e.
+        // the current high-water) is NOT reset and filters correctly to empty.
+        // Note: a cursor STRICTLY above the high-water is treated as stranded and
+        // reset — see `test_fetch_notes_resets_cursor_stranded_above_high_water`.
+        let all = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        let caught_up_cursor = u64::try_from(all[0].seq).expect("seq is non-negative");
+        let empty = db.fetch_notes(TAG_LOCAL_ANY.into(), caught_up_cursor).await.unwrap();
+        assert_eq!(
+            empty.len(),
+            0,
+            "caught-up cursor (== high-water) filters correctly and does not reset"
+        );
+    }
+
+    /// A cursor STRICTLY ABOVE the current `seq` high-water can only exist if the
+    /// server's seq space regressed beneath a client's stored cursor (the backing
+    /// DB was recreated and AUTOINCREMENT restarted low). Such a cursor is below
+    /// the legacy-timestamp threshold, so the legacy guard never fires; without
+    /// the stranded reset it would match `seq > cursor` = nothing, forever.
+    #[tokio::test]
+    async fn test_fetch_notes_resets_cursor_stranded_above_high_water() {
+        let db = Database::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap();
+
+        // Populate the current epoch with two notes (high-water becomes their max seq).
+        for details in [vec![1u8], vec![2u8]] {
+            db.store_note(&StoredNote {
+                header: test_note_header(),
+                details,
+                created_at: Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        let all = db.fetch_notes(TAG_LOCAL_ANY.into(), 0).await.unwrap();
+        assert_eq!(all.len(), 2, "sanity: both notes present in this epoch");
+        let high_water = u64::try_from(all[1].seq).expect("seq is non-negative");
+
+        // Caught-up client (cursor == high-water) must NOT reset — else it would
+        // re-deliver the whole backlog on every steady-state poll.
+        let caught_up = db.fetch_notes(TAG_LOCAL_ANY.into(), high_water).await.unwrap();
+        assert_eq!(caught_up.len(), 0, "caught-up cursor must not be reset");
+
+        // Stranded cursor (well above high-water, far below the 1e12 legacy
+        // threshold) resets to 0, recovers the epoch, and reports effective 0 so
+        // the caller can heal the client's stored cursor.
+        let stranded = high_water + 5_000;
+        let (recovered, effective) =
+            db.fetch_notes_by_tags(&[TAG_LOCAL_ANY.into()], stranded).await.unwrap();
+        assert_eq!(
+            recovered.len(),
+            2,
+            "cursor above high-water must reset to 0 and recover the epoch"
+        );
+        assert_eq!(
+            effective, 0,
+            "effective cursor must be 0 so the echoed response cursor heals the client"
+        );
     }
 
     /// Pagination: a response is capped at `FETCH_NOTES_BATCH_SIZE` rows. A

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -40,6 +40,10 @@ pub trait DatabaseBackend: Send + Sync {
     /// or stranded above the seq high-water), otherwise the requested cursor.
     /// Callers should base their response cursor on this effective value so a
     /// reset heals the client rather than re-triggering every poll.
+    ///
+    /// An empty tag set short-circuits before the stranded-cursor check and
+    /// returns the post-legacy cursor unchanged (there are no notes to deliver,
+    /// so there is nothing to heal).
     async fn fetch_notes_by_tags(
         &self,
         tags: &[NoteTag],

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -41,9 +41,10 @@ const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
 /// [`SqliteDatabase::fetch_notes_by_tags`] for how that stranded cursor is reset.
 ///
 /// Returns `None` when the high-water can't be determined (no note ever inserted,
-/// or the sequence bookkeeping is unavailable). Callers MUST then treat no cursor
-/// as stranded — fail-safe, so a fetch can never fail or falsely reset a live
-/// client because of this check.
+/// or the sequence bookkeeping is unavailable). The caller then SKIPS the
+/// stranded-cursor check entirely, leaving the cursor unchanged — fail-safe, so a
+/// transient unavailability of `sqlite_sequence` can never fail a fetch or falsely
+/// reset a live client.
 fn high_water_seq(conn: &mut SqliteConnection) -> Option<i64> {
     #[derive(diesel::QueryableByName)]
     struct HighWater {
@@ -233,6 +234,11 @@ impl DatabaseBackend for SqliteDatabase {
             .transact("fetch notes by tags", move |conn| {
                 use schema::notes::dsl::{notes, seq, tag};
 
+                // Only a non-zero cursor can be stranded. This guard also makes
+                // the heal converge: a reset lands the client (and, on the push
+                // path, the stored subscription cursor) at 0, and cursor 0 never
+                // re-enters this branch — so the reset fires at most once per
+                // stranding event, not every poll.
                 let mut effective = cursor_i64;
                 if effective > 0 {
                     if let Some(high_water) = high_water_seq(conn) {

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -236,6 +236,14 @@ impl DatabaseBackend for SqliteDatabase {
                 let mut effective = cursor_i64;
                 if effective > 0 {
                     if let Some(high_water) = high_water_seq(conn) {
+                        // Strict `>` is deliberate: a caught-up client sits at
+                        // `cursor == high_water` and must NOT be reset (that would
+                        // re-deliver the whole epoch every steady-state poll). The
+                        // accepted residual edge is that if a recreated epoch grows
+                        // to exactly the stranded cursor before the client's next
+                        // poll, the reset is skipped and the client misses that
+                        // epoch's `1..=cursor` backlog — a one-insert-wide
+                        // coincidence with bounded impact.
                         if effective > high_water {
                             effective = 0;
                         }

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -31,6 +31,42 @@ pub(crate) const FETCH_NOTES_BATCH_SIZE: i64 = 500;
 /// and two orders of magnitude below any microsecond timestamp this decade.
 const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
 
+/// AUTOINCREMENT high-water mark for the `notes` table (`sqlite_sequence.seq`):
+/// the maximum `seq` ever allocated in this DB file's lifetime.
+///
+/// AUTOINCREMENT guarantees this never decreases within a single lifetime — it
+/// survives `DELETE`, `VACUUM` and `cleanup_old_notes` — so a client cursor that
+/// is strictly above it can only have come from a *different* (larger) seq space
+/// that no longer exists, i.e. the backing DB was recreated. See
+/// [`SqliteDatabase::fetch_notes_by_tags`] for how that stranded cursor is reset.
+///
+/// Returns `None` when the high-water can't be determined (no note ever inserted,
+/// or the sequence bookkeeping is unavailable). Callers MUST then treat no cursor
+/// as stranded — fail-safe, so a fetch can never fail or falsely reset a live
+/// client because of this check.
+fn high_water_seq(conn: &mut SqliteConnection) -> Option<i64> {
+    #[derive(diesel::QueryableByName)]
+    struct HighWater {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        seq: i64,
+    }
+
+    // `sqlite_sequence` is SQLite bookkeeping, not part of the Diesel schema, so
+    // query it with raw SQL. `.optional()` maps "no row for notes yet" (nothing
+    // inserted) to `None`; any other error also degrades to `None` so this check
+    // is purely advisory and can never break a fetch.
+    match diesel::sql_query("SELECT seq FROM sqlite_sequence WHERE name = 'notes'")
+        .get_result::<HighWater>(conn)
+        .optional()
+    {
+        Ok(row) => row.map(|r| r.seq),
+        Err(err) => {
+            tracing::debug!(?err, "sqlite_sequence unreadable; skipping stranded-cursor check");
+            None
+        },
+    }
+}
+
 /// `SQLite` implementation of the database backend
 pub struct SqliteDatabase {
     pool: deadpool_diesel::Pool<ConnectionManager, deadpool::managed::Object<ConnectionManager>>,
@@ -137,7 +173,9 @@ impl DatabaseBackend for SqliteDatabase {
         tag: NoteTag,
         cursor: u64,
     ) -> Result<Vec<StoredNote>, DatabaseError> {
-        self.fetch_notes_by_tags(&[tag], cursor).await
+        // Single-tag convenience: drop the effective cursor (only the gRPC
+        // fetch handler needs it, to base its response cursor on the reset).
+        Ok(self.fetch_notes_by_tags(&[tag], cursor).await?.0)
     }
 
     #[tracing::instrument(skip(self, tags), fields(
@@ -150,28 +188,27 @@ impl DatabaseBackend for SqliteDatabase {
         &self,
         tags: &[NoteTag],
         cursor: u64,
-    ) -> Result<Vec<StoredNote>, DatabaseError> {
+    ) -> Result<(Vec<StoredNote>, u64), DatabaseError> {
         let timer = self.metrics.db_fetch_notes();
 
         // Legacy cursor detection: clients upgraded from the pre-`seq` schema
         // carry microsecond-timestamp cursors; interpret those as 0 so they
         // don't stall forever waiting for `seq` to catch up. Record a metric
         // so operators can see when pre-migration clients are being reset.
-        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD {
+        let legacy_reset = cursor > LEGACY_CURSOR_THRESHOLD;
+        if legacy_reset {
             self.metrics.db_fetch_notes_legacy_cursor_reset();
             tracing::info!(original_cursor = cursor, "Legacy cursor reset to 0");
-            0
-        } else {
-            cursor
-        };
+        }
+        let post_legacy_cursor = if legacy_reset { 0 } else { cursor };
 
-        let cursor_i64: i64 = effective_cursor.try_into().map_err(|_| {
+        let cursor_i64: i64 = post_legacy_cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())
         })?;
 
         if tags.is_empty() {
             timer.finish("ok");
-            return Ok(Vec::new());
+            return Ok((Vec::new(), post_legacy_cursor));
         }
 
         let tag_values: Vec<i64> = tags.iter().map(|t| i64::from(t.as_u32())).collect();
@@ -183,21 +220,51 @@ impl DatabaseBackend for SqliteDatabase {
         //
         // LIMIT caps response size; a backlogged client paginates by re-calling
         // with the returned cursor until the response is smaller than the limit.
-        let notes: Vec<Note> = self
+        //
+        // Stranded-cursor detection runs in the SAME snapshot so the high-water
+        // is consistent with the rows read: a non-zero cursor strictly above the
+        // AUTOINCREMENT high-water can only come from a regressed seq space (the
+        // backing DB was recreated), and — unlike a legacy µs cursor — it is a
+        // plausible small `seq`, so `LEGACY_CURSOR_THRESHOLD` never catches it.
+        // Reset it to 0 so the client re-scans the current epoch; the effective
+        // cursor returned below lets the caller heal the client's stored position
+        // (see the gRPC fetch handler) instead of re-triggering the reset forever.
+        let (notes, effective_i64): (Vec<Note>, i64) = self
             .transact("fetch notes by tags", move |conn| {
                 use schema::notes::dsl::{notes, seq, tag};
+
+                let mut effective = cursor_i64;
+                if effective > 0 {
+                    if let Some(high_water) = high_water_seq(conn) {
+                        if effective > high_water {
+                            effective = 0;
+                        }
+                    }
+                }
+
                 let fetched_notes = notes
                     .filter(tag.eq_any(&tag_values))
-                    .filter(seq.gt(cursor_i64))
+                    .filter(seq.gt(effective))
                     .order(seq.asc())
                     .limit(FETCH_NOTES_BATCH_SIZE)
                     // Name-based column selection (via `Selectable`) so a future
                     // mid-table column insert can't silently misalign fields.
                     .select(Note::as_select())
                     .load(conn)?;
-                Ok(fetched_notes)
+                Ok((fetched_notes, effective))
             })
             .await?;
+
+        // A post-legacy cursor that came back as 0 was reset by the high-water
+        // check above (a legacy reset already zeroed `post_legacy_cursor`, so it
+        // is excluded by the `> 0` guard and never counted here).
+        if post_legacy_cursor > 0 && effective_i64 == 0 {
+            self.metrics.db_fetch_notes_stranded_cursor_reset();
+            tracing::warn!(
+                original_cursor = cursor,
+                "Cursor above seq high-water reset to 0 (server seq space regressed; DB recreated)"
+            );
+        }
 
         let mut stored_notes = Vec::new();
         for note in notes {
@@ -210,7 +277,8 @@ impl DatabaseBackend for SqliteDatabase {
         tracing::Span::current().record("notes_returned", stored_notes.len());
         timer.finish("ok");
 
-        Ok(stored_notes)
+        let effective_cursor: u64 = effective_i64.try_into().unwrap_or(0);
+        Ok((stored_notes, effective_cursor))
     }
 
     async fn get_stats(&self) -> Result<(u64, u64), DatabaseError> {

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -39,6 +39,8 @@ pub struct MetricsDatabase {
     fetch_notes_duration: Histogram<f64>,
     // legacy cursor reset (pre-seq-migration clients)
     fetch_notes_legacy_cursor_reset_count: Counter<u64>,
+    // stranded cursor reset (cursor above the seq high-water → DB recreated)
+    fetch_notes_stranded_cursor_reset_count: Counter<u64>,
     // Maintenance
     maintenance_cleanup_notes_count: Counter<u64>,
     maintenance_cleanup_notes_duration: Histogram<f64>,
@@ -178,6 +180,16 @@ impl MetricsDatabase {
             )
             .build();
 
+        let fetch_notes_stranded_cursor_reset_count = meter
+            .u64_counter("db_fetch_notes_stranded_cursor_reset_count")
+            .with_description(
+                "Number of fetch_notes() requests where the client's cursor was at or \
+                 below the legacy threshold but strictly above the current seq \
+                 high-water and reset to 0 (server seq space regressed — backing DB \
+                 recreated)",
+            )
+            .build();
+
         let maintenance_cleanup_notes_count = meter
             .u64_counter("db_maintenance_cleanup_notes_count")
             .with_description("Total number of DB maintenance cleanup_old_notes() requests")
@@ -195,6 +207,7 @@ impl MetricsDatabase {
             fetch_notes_count,
             fetch_notes_duration,
             fetch_notes_legacy_cursor_reset_count,
+            fetch_notes_stranded_cursor_reset_count,
             maintenance_cleanup_notes_count,
             maintenance_cleanup_notes_duration,
         }
@@ -225,6 +238,12 @@ impl MetricsDatabase {
     /// Record a legacy-cursor reset (pre-seq-migration client).
     pub fn db_fetch_notes_legacy_cursor_reset(&self) {
         self.fetch_notes_legacy_cursor_reset_count.add(1, &[]);
+    }
+
+    /// Record a stranded-cursor reset: the client's cursor was above the current
+    /// seq high-water and reset to 0 (server seq space regressed — DB recreated).
+    pub fn db_fetch_notes_stranded_cursor_reset(&self) {
+        self.fetch_notes_stranded_cursor_reset_count.add(1, &[]);
     }
 
     /// Measure a DB maintenance cleanup-old-notes procedure

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -391,4 +391,44 @@ mod tests {
         assert_eq!(response.notes.len(), 0, "DB is empty, no notes returned");
         assert_eq!(response.cursor, 0);
     }
+
+    /// End-to-end heal: a cursor stranded above the seq high-water (but below the
+    /// legacy threshold) must reset AND the echoed response cursor must be the
+    /// recovered seq — not the stranded value echoed back. This is the actual
+    /// client-healing mechanism; the DB-layer tests only prove `effective == 0`,
+    /// so without this a regression reverting `rcursor = effective_cursor` back
+    /// to `= cursor` would pass every other test while silently re-breaking the
+    /// fix (and re-introducing the analogous latent legacy-cursor bug).
+    #[tokio::test]
+    async fn test_fetch_notes_response_cursor_heals_stranded_client() {
+        use chrono::Utc;
+
+        use crate::test_utils::{TAG_LOCAL_ANY, test_note_header};
+        use crate::types::StoredNote;
+
+        let server = test_server().await;
+        server
+            .database
+            .store_note(&StoredNote {
+                header: test_note_header(),
+                details: vec![9],
+                created_at: Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap(); // high-water becomes 1
+
+        // Stranded cross-epoch cursor: far above the high-water (1), far below
+        // the 1e12 legacy threshold.
+        let request =
+            tonic::Request::new(FetchNotesRequest { tags: vec![TAG_LOCAL_ANY], cursor: 5_000 });
+        let response = server.fetch_notes(request).await.expect("must succeed").into_inner();
+
+        assert_eq!(response.notes.len(), 1, "stranded cursor must reset to 0 and recover the note");
+        assert_eq!(
+            response.cursor, 1,
+            "response cursor must be the recovered seq (heal), not the stranded 5000 echoed back"
+        );
+    }
 }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -431,4 +431,41 @@ mod tests {
             "response cursor must be the recovered seq (heal), not the stranded 5000 echoed back"
         );
     }
+
+    /// Stranded cursor on a tag with NO matching notes in the new epoch: the
+    /// reset still heals the echoed cursor to 0 (so the client re-scans from the
+    /// start next poll) even though no notes come back — the `rcursor` base must
+    /// be the effective cursor (0), not the stranded value.
+    #[tokio::test]
+    async fn test_fetch_notes_response_cursor_heals_when_no_matching_notes() {
+        use chrono::Utc;
+
+        use crate::test_utils::{TAG_LOCAL_ANY, test_note_header_with_tag};
+        use crate::types::StoredNote;
+
+        let server = test_server().await;
+        // A note under a DIFFERENT tag lifts the high-water to 1; the requested
+        // tag has no notes in this epoch.
+        server
+            .database
+            .store_note(&StoredNote {
+                header: test_note_header_with_tag(0xc000_0001),
+                details: vec![7],
+                created_at: Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap();
+
+        let request =
+            tonic::Request::new(FetchNotesRequest { tags: vec![TAG_LOCAL_ANY], cursor: 5_000 });
+        let response = server.fetch_notes(request).await.expect("must succeed").into_inner();
+
+        assert_eq!(response.notes.len(), 0, "requested tag has no notes in the new epoch");
+        assert_eq!(
+            response.cursor, 0,
+            "stranded cursor must heal to 0, not echo the stranded 5000 back, even with no notes"
+        );
+    }
 }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -242,13 +242,20 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
         // two per-tag queries and get leapfrogged when rcursor advanced past
         // its seq on the next fetch. A single `tag IN (…)` query reads all
         // matching rows in one consistent snapshot.
-        let stored_notes = self
+        let (stored_notes, effective_cursor) = self
             .database
             .fetch_notes_by_tags(&tags, cursor)
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
-        let mut rcursor = cursor;
+        // Base the response cursor on the EFFECTIVE cursor used for the query, not
+        // the client's claimed one. When the claimed cursor was reset (legacy µs
+        // cursor, or stranded above the seq high-water after a DB recreation),
+        // `effective_cursor` is 0, so the echoed cursor becomes the max seq we
+        // actually returned — the client's next poll then starts from the true
+        // epoch position and heals, instead of re-sending its stranded cursor and
+        // re-triggering the reset on every request.
+        let mut rcursor = effective_cursor;
         for stored_note in &stored_notes {
             let seq_cursor: u64 = stored_note
                 .seq

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -392,7 +392,7 @@ mod tests {
         mgr.update_timestamps(&updates);
         mgr.forward_updates(updates);
 
-        assert_eq!(mgr.tags.get(&tag).unwrap().cursor, 0, "stored cursor healed to 0 exactly once",);
+        assert_eq!(mgr.tags.get(&tag).unwrap().cursor, 0, "stored cursor healed to 0 exactly once");
         assert!(rx.try_recv().is_err(), "no empty update may reach the subscriber");
 
         // Tick 2: caught-up at 0 — the `effective > 0` guard skips the high-water

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -141,6 +141,8 @@ impl NoteStreamerManager {
         for (tag, notes) in tag_notes {
             // Cursor-only heal entries carry no notes; `update_timestamps` has
             // already advanced the stored cursor, and there is nothing to send.
+            // The subscriber's waker stays in `self.wakers` (unconsumed) and is
+            // woken when notes next arrive for the tag, or dropped on disconnect.
             if notes.0.is_empty() {
                 continue;
             }
@@ -327,5 +329,123 @@ impl Drop for Sub {
         }) {
             tracing::error!(subscription_id = %self.id, error = %e, "Streamer remove sub control message sending error");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::database::{Database, DatabaseConfig};
+    use crate::metrics::Metrics;
+    use crate::test_utils::{TAG_LOCAL_ANY, test_note_header_with_tag};
+    use crate::types::StoredNote;
+
+    /// A streaming subscription stranded above the seq high-water (its cursor
+    /// carried over a DB recreation) whose tag has NO notes in the new epoch must
+    /// heal its stored cursor to 0 exactly once — not re-fire the reset (warn +
+    /// metric) on every 500ms tick — and must NOT push an empty update, which
+    /// would deliver `cursor: 0` to the client and regress its position. The
+    /// `forward_updates` empty-skip guard is load-bearing for that last property:
+    /// with a waker registered, removing the guard would deliver the empty batch
+    /// and fail this test.
+    #[tokio::test]
+    async fn test_streaming_heals_stranded_cursor_without_spurious_push() {
+        let db = Arc::new(
+            Database::connect(DatabaseConfig::default(), Metrics::default().db)
+                .await
+                .unwrap(),
+        );
+
+        // A note under a DIFFERENT tag: the shared seq high-water becomes 1,
+        // while the subscribed tag has no notes in this epoch.
+        db.store_note(&StoredNote {
+            header: test_note_header_with_tag(0xc000_0001),
+            details: vec![1],
+            created_at: Utc::now(),
+            seq: 0,
+            after_block_num: None,
+        })
+        .await
+        .unwrap();
+
+        let mut mgr = NoteStreamerManager::new(db);
+
+        // Register a subscriber on TAG_LOCAL_ANY with a stranded shared cursor,
+        // plus a waker so `forward_updates` WOULD deliver if the empty-skip guard
+        // were removed — making the "no spurious push" assertion meaningful.
+        let tag: NoteTag = TAG_LOCAL_ANY.into();
+        let (tx, mut rx) = mpsc::channel::<TransportNotesPg>(4);
+        let mut subs = BTreeMap::new();
+        subs.insert(1u64, SubEntry { tx, created_at: Instant::now() });
+        mgr.tags.insert(tag, TagData { cursor: 10_000, subs });
+        mgr.update_waker(1, Waker::noop().clone());
+
+        // Tick 1: cursor (10_000) is above the high-water (1) → reset →
+        // cursor-only heal entry (empty notes, cursor 0).
+        let updates = mgr.query_updates().await.unwrap();
+        assert_eq!(updates.len(), 1, "stranded empty tag must emit one cursor-only heal");
+        assert!(updates[0].1.0.is_empty(), "heal carries no notes");
+        assert_eq!(updates[0].1.1, 0, "heal cursor is the reset value 0");
+
+        mgr.update_timestamps(&updates);
+        mgr.forward_updates(updates);
+
+        assert_eq!(mgr.tags.get(&tag).unwrap().cursor, 0, "stored cursor healed to 0 exactly once",);
+        assert!(rx.try_recv().is_err(), "no empty update may reach the subscriber");
+
+        // Tick 2: caught-up at 0 — the `effective > 0` guard skips the high-water
+        // check entirely, so no reset and no push. The storm is gone.
+        assert!(
+            mgr.query_updates().await.unwrap().is_empty(),
+            "steady state after heal produces no push (no storm)",
+        );
+    }
+
+    /// A stranded subscription whose tag DOES have notes in the new epoch heals
+    /// and delivers those notes in a single tick: the reset re-scans from 0, the
+    /// recovered notes are forwarded to the subscriber, and the stored cursor
+    /// advances to their max seq (not 0, not the stranded value). Covers the
+    /// heal + non-empty `forward_updates` + waker-consumption path.
+    #[tokio::test]
+    async fn test_streaming_heals_stranded_cursor_and_delivers_notes() {
+        let db = Arc::new(
+            Database::connect(DatabaseConfig::default(), Metrics::default().db)
+                .await
+                .unwrap(),
+        );
+
+        // Two notes on the SUBSCRIBED tag: the high-water becomes 2.
+        for details in [vec![1u8], vec![2u8]] {
+            db.store_note(&StoredNote {
+                header: test_note_header_with_tag(TAG_LOCAL_ANY),
+                details,
+                created_at: Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        let mut mgr = NoteStreamerManager::new(db);
+        let tag: NoteTag = TAG_LOCAL_ANY.into();
+        let (tx, mut rx) = mpsc::channel::<TransportNotesPg>(4);
+        let mut subs = BTreeMap::new();
+        subs.insert(1u64, SubEntry { tx, created_at: Instant::now() });
+        mgr.tags.insert(tag, TagData { cursor: 10_000, subs });
+        mgr.update_waker(1, Waker::noop().clone());
+
+        let updates = mgr.query_updates().await.unwrap();
+        mgr.update_timestamps(&updates);
+        mgr.forward_updates(updates);
+
+        // The subscriber received the recovered notes (heal + delivery)...
+        let (notes, cursor) = rx.try_recv().expect("healed notes must be delivered");
+        assert_eq!(notes.len(), 2, "both new-epoch notes recovered");
+        assert_eq!(cursor, 2, "delivered cursor is the max recovered seq");
+        // ...and the stored cursor advanced to the max seq (not 0, not stranded).
+        assert_eq!(mgr.tags.get(&tag).unwrap().cursor, 2, "stored cursor healed to max seq");
     }
 }

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -118,7 +118,16 @@ impl NoteStreamerManager {
             let pnotes = snotes.into_iter().map(TransportNote::from).collect::<Vec<_>>();
             let notespg = (pnotes, cursor);
 
-            if !notespg.0.is_empty() {
+            // Push when there are notes to forward, OR when the cursor changed
+            // with no notes. The latter is a cursor-only heal: a stranded
+            // subscription (cursor above the seq high-water after a DB
+            // recreation) whose tag has no notes in the new epoch resets to
+            // `effective = 0` every tick but, without this, would never persist
+            // that reset — re-firing the reset (and its warn log + metric) on
+            // every 500ms tick. Including it lets `update_timestamps` advance the
+            // stored cursor once; `forward_updates` skips the empty batch so no
+            // empty update reaches subscribers.
+            if !notespg.0.is_empty() || cursor != tag_data.cursor {
                 updates.push((*tag, notespg));
             }
         }
@@ -130,6 +139,11 @@ impl NoteStreamerManager {
         let mut remove_subs = vec![];
         // Forward updates to subs
         for (tag, notes) in tag_notes {
+            // Cursor-only heal entries carry no notes; `update_timestamps` has
+            // already advanced the stored cursor, and there is nothing to send.
+            if notes.0.is_empty() {
+                continue;
+            }
             if let Some(tag_data) = self.tags.get(&tag) {
                 // Wake-up subs with `tag`
                 for (sub_id, sub_entry) in &tag_data.subs {

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -94,8 +94,15 @@ impl NoteStreamerManager {
 
         let mut updates = vec![];
         for (tag, tag_data) in &self.tags {
-            let snotes = self.database.fetch_notes(*tag, tag_data.cursor).await?;
-            let mut cursor = tag_data.cursor;
+            // Use the tuple-returning fetch so a reset (legacy µs cursor, or a
+            // cursor stranded above the seq high-water after a DB recreation)
+            // flows into the advanced cursor. Basing the advance on the effective
+            // cursor — not `tag_data.cursor` — lets a stranded subscription heal
+            // instead of re-sending its stranded cursor and re-triggering the
+            // reset (and re-delivering the whole backlog) on every tick.
+            let (snotes, effective_cursor) =
+                self.database.fetch_notes_by_tags(&[*tag], tag_data.cursor).await?;
+            let mut cursor = effective_cursor;
             for snote in &snotes {
                 // Advance cursor using the DB-assigned monotonic `seq`
                 // (matches the pull-side fetch_notes contract). Using


### PR DESCRIPTION
## Problem

A wallet whose stored transport cursor is **higher than the server's current max `seq`** fetches **zero notes forever**. Every `fetch_notes(seq > cursor)` matches nothing, and the handler echoes `rcursor = max(cursor, max_seq_returned)` — so the too-high cursor is returned verbatim and never decreases. Notes correctly addressed to that wallet sit on the server, undeliverable, with no self-healing on either side.

This was found in the wild: a testnet wallet holding cursor `3487` against a server whose max `seq` is `812`. `FetchNotes(tags, cursor=0)` returns the notes; `cursor=3487` returns nothing. Full root-cause writeup: the mechanism is verified against `origin/main` (client persists only server-echoed cursors; `LEGACY_CURSOR_THRESHOLD = 1e12` doesn't catch a small value like `3487`).

### How a cursor ends up above the max seq

The client only ever persists a server-echoed `rcursor` (`= max(seen seqs)`), so a stored cursor above the current max `seq` can only mean the server's **seq space regressed**: the backing DB was recreated (volume reset / restore-from-empty / endpoint swap) and `AUTOINCREMENT` restarted low, while the client still holds a cursor from the previous, larger epoch. The `add_seq_cursor` migration itself backfills `seq` in `created_at` order and its comment assumes a single deployment lifetime — this is the blind spot of that assumption.

## Fix

Detect a **stranded cursor** — one at/below the legacy threshold but **strictly above the current `seq` high-water** — and reset it to `0` so the client re-scans the current epoch. `sqlite_sequence.seq` (the `AUTOINCREMENT` high-water) is the right signal: it **only decreases across a DB recreation**, never within a lifetime (survives `DELETE`/`VACUUM`/`cleanup_old_notes`). A legitimately caught-up client sits at `cursor == high_water` and is untouched — so **no false positives**.

Crucially, the reset must also **heal the echoed cursor**: `fetch_notes_by_tags` now returns the *effective* cursor it used, and the gRPC handler bases `rcursor` on that (not the client's claimed cursor). Without this, the handler would keep echoing the stranded `3487` and the client would re-download the whole epoch on every poll and never converge. Basing the echo on the effective cursor lets a stranded client heal in 1–2 polls and paginate normally.

**Bonus:** this same echo change fixes the pre-existing legacy-µs-cursor path, which had the identical "re-download every poll, never heal" behavior.

Both the pull path (`fetch_notes`) and the push path (`streaming.rs`) are covered.

## Changes
- `sqlite/mod.rs`: `high_water_seq()` helper (reads `sqlite_sequence`, fail-safe `None` on any error → never falsely resets); stranded-cursor detection in `fetch_notes_by_tags`, run in the same snapshot as the query; returns `(notes, effective_cursor)`.
- `grpc/mod.rs`: base the response cursor on the effective cursor.
- `streaming.rs`: advance the subscription cursor from the effective cursor.
- `metrics.rs`: `db_fetch_notes_stranded_cursor_reset_count` counter (mirrors the legacy-reset counter) so operators can see it fire.
- `database/mod.rs`: trait/wrapper signature update; new test `test_fetch_notes_resets_cursor_stranded_above_high_water`; updated the legacy-reset test's sanity check (see below).

## Behavior change (intentional)
A `fetch_notes` cursor **strictly above the current high-water** is now reset to `0` instead of returning empty. The existing `test_fetch_notes_resets_legacy_cursor` had a sanity check asserting that `cursor=1000` against a one-note DB (seq `1`) returns empty; that scenario is exactly a stranded cursor, so its assertion was updated to use a caught-up cursor (`== high_water`), which is the genuine "no reset" case.

## Assumption
The reset assumes a **single shared seq space** (single writer / shared volume). A sharded deployment with independent per-instance seq spaces behind a naive load balancer would thrash — but such a deployment is already incompatible with cursor semantics, and the analysis confirmed a single logical seq space (all backend IPs returned identical results). A sharded setup would need epoch-in-cursor instead; noted as a follow-up if that ever changes.

## Verification
- `cargo test -p miden-note-transport-node` — 17/17 pass (new + updated tests included; `test_fetch_notes_paginates_at_batch_limit` confirms normal backlog pagination is undisturbed — during pagination the cursor is always ≤ high-water).
- `CLIPPY_CONF_DIR=configs cargo clippy --locked --all-targets --workspace -- -D warnings` — clean.
- `cargo +nightly fmt --all --check` (repo config) — clean.

Draft: opening for review. No migration and no wire-format change; fixes every already-deployed client with no client update. A complementary client-side change (SDK `fetch_all_private_notes` never-regress guard) is optional defense-in-depth but not required once this lands.
