### PR TITLE
Bump transport crate versions to 0.5.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node"
-version = "0.4.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-node-bin"
-version = "0.4.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "clap",
  "miden-note-transport-node",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto"
-version = "0.4.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "fs-err",
  "miette",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.1"
+version = "0.5.0-alpha.1"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/miden-note-transport"
 rust-version = "1.96.1"
-version      = "0.4.1"
+version      = "0.5.0-alpha.1"
 
 [workspace.dependencies]
 # Workspace crates (path-based dependencies)
-miden-note-transport-node        = { path = "crates/node", version = "0.4.1" }
-miden-note-transport-proto       = { path = "crates/proto", version = "0.4.1" }
-miden-note-transport-proto-build = { path = "proto", version = "0.4.1" }
+miden-note-transport-node        = { path = "crates/node", version = "0.5.0-alpha.1" }
+miden-note-transport-proto       = { path = "crates/proto", version = "0.5.0-alpha.1" }
+miden-note-transport-proto-build = { path = "proto", version = "0.5.0-alpha.1" }
 
 # miden-base aka protocol dependencies (git = "https://github.com/0xMiden/miden-base"). These should be updated in sync.
 miden-protocol = { default-features = false, version = "0.16.0-alpha.2" }


### PR DESCRIPTION
## Summary
- Bump `miden-note-transport-node`, `miden-note-transport-proto`, and `miden-note-transport-proto-build` (workspace version) from `0.4.1` to `0.5.0-alpha.1`, in preparation for the `v0.5.0-alpha` release.
- Regenerate `Cargo.lock` to match.

## Test plan
- [x] `cargo check --workspace`
- [x] `make lint`
- [x] `cargo test --workspace`