### PR TITLE
feat(github): add Docker build check and publish workflows

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,47 @@
+name: Docker Build Check
+
+on:
+  push:
+    branches: [main, "release/v*"]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+env:
+  DOCKER_PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  docker-build:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: warp-ubuntu-latest-x64-8x
+    name: Build Note Transport Service
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Prepare image metadata
+        id: metadata
+        run: |
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
+        with:
+          context: .
+          push: false
+          file: ./bin/node/docker/Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
+          pull: true
+          build-args: |
+            CREATED=${{ steps.metadata.outputs.created }}
+            VERSION=${{ steps.metadata.outputs.version }}
+            COMMIT=${{ steps.metadata.outputs.commit }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,48 +1,65 @@
-name: Docker Build Check
+name: Publish Docker image
 
 on:
   push:
-    branches: [main, "release/v*"]
-  pull_request:
-    types: [opened, reopened, synchronize]
+    tags:
+      - "v*"
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 env:
+  REGISTRY: ghcr.io
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
-  docker-build:
-    name: Build Note Transport Service
-    permissions:
-      contents: read
-      id-token: write
+  publish-docker:
+    name: Publish Docker image
     runs-on: warp-ubuntu-latest-x64-8x
     if: ${{ github.repository_owner == '0xMiden' }}
+    environment: publish-docker
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare image metadata
         id: metadata
         run: |
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "version=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
-      - name: Build
+      - name: Build and push Docker image
         uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
         with:
           context: .
-          push: false
+          push: true
           file: ./bin/node/docker/Dockerfile
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
-          pull: true
+          pull: false
           build-args: |
             CREATED=${{ steps.metadata.outputs.created }}
             VERSION=${{ steps.metadata.outputs.version }}
             COMMIT=${{ steps.metadata.outputs.commit }}
+          tags: ${{ env.REGISTRY }}/0xmiden/miden-note-transport:${{ github.ref_name }}

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -11,6 +11,10 @@ repository.workspace   = true
 rust-version.workspace = true
 version.workspace      = true
 
+[[bin]]
+name = "miden-note-transport-node"
+path = "src/main.rs"
+
 [lints]
 workspace = true
 

--- a/bin/node/README.md
+++ b/bin/node/README.md
@@ -9,7 +9,7 @@ To build from source, run
 cargo build --release --locked
 ```
 
-The binary will be available on `./target/release/miden-note-transport-node-bin`.
+The binary will be available on `./target/release/miden-note-transport-node`.
 
 ## Docker setup
 

--- a/bin/node/docker/Dockerfile
+++ b/bin/node/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Miden Note Transport Node
-FROM rust:1.90-slim-bookworm as builder
+FROM rust:1.96-slim-bookworm as builder
 
 
 

--- a/bin/node/docker/Dockerfile
+++ b/bin/node/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/local/cargo/bin/miden-note-transport-node-bin /usr/local/bin/miden-note-transport-node-bin
+COPY --from=builder /usr/local/cargo/bin/miden-note-transport-node /usr/local/bin/miden-note-transport-node
 
 LABEL org.opencontainers.image.authors=devops@miden.team \
     org.opencontainers.image.url=https://0xMiden.github.io/ \
@@ -46,4 +46,4 @@ LABEL org.opencontainers.image.created=$CREATED \
 # Expose port
 EXPOSE 57292
 
-CMD ["miden-note-transport-node-bin", "--host", "0.0.0.0"]
+CMD ["miden-note-transport-node", "--host", "0.0.0.0"]

--- a/bin/node/docker/Dockerfile
+++ b/bin/node/docker/Dockerfile
@@ -1,11 +1,9 @@
 # Miden Note Transport Node
-FROM rust:1.96-slim-bookworm as builder
-
-
+FROM rust:1.96-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y llvm clang bindgen pkg-config libssl-dev libsqlite3-dev ca-certificates && \
+    apt-get install -y llvm clang bindgen pkg-config libsqlite3-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -20,11 +18,11 @@ RUN cargo install --path bin/node --locked
 FROM debian:bookworm-slim
 
 # Update machine & install required packages
-# The installation of sqlite3 is needed for correct function of the SQLite database
+# The installation of libsqlite3-0 is needed because the binary is linked against it
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-    sqlite3 \
+    libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/cargo/bin/miden-note-transport-node /usr/local/bin/miden-note-transport-node

--- a/bin/node/docker/docker-compose.yml
+++ b/bin/node/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: bin/node/docker/Dockerfile
     ports:
       - "57292:57292"  # gRPC
-    command: ["miden-note-transport-node-bin", "--host", "0.0.0.0", "--database-url", "/app/data/node.db"]
+    command: ["miden-note-transport-node", "--host", "0.0.0.0", "--database-url", "/app/data/node.db"]
     environment:
       - JSON_LOGGING=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317

--- a/docs/external/src/operators.md
+++ b/docs/external/src/operators.md
@@ -15,20 +15,20 @@ From the repository root:
 cargo install --path bin/node --locked
 ```
 
-This installs the `miden-note-transport-node-bin` binary.
+This installs the `miden-note-transport-node` binary.
 
 ## Run the node
 
 The default configuration binds to localhost and stores notes in an in-memory SQLite database:
 
 ```bash
-miden-note-transport-node-bin
+miden-note-transport-node
 ```
 
 For a reachable node with persistent storage:
 
 ```bash
-miden-note-transport-node-bin \
+miden-note-transport-node \
   --host 0.0.0.0 \
   --port 57292 \
   --database-url /var/lib/miden-note-transport/node.db \
@@ -67,7 +67,7 @@ OTEL_ENABLED=true \
 OTEL_TRACES_ENDPOINT=http://otel-collector:4317 \
 JSON_LOGGING=true \
 RUST_LOG=INFO \
-miden-note-transport-node-bin --host 0.0.0.0 --database-url /var/lib/miden-note-transport/node.db
+miden-note-transport-node --host 0.0.0.0 --database-url /var/lib/miden-note-transport/node.db
 ```
 
 ## Docker Compose

--- a/docs/src/operator/installation.md
+++ b/docs/src/operator/installation.md
@@ -18,16 +18,16 @@ Then use `cargo` to compile the node from the source code:
 
 ```sh
 # Install latest version
-cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node-bin
+cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node
 
 # Install from a specific branch
-cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node-bin --branch <branch>
+cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node --branch <branch>
 
 # Install a specific tag
-cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node-bin --tag <tag>
+cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node --tag <tag>
 
 # Install a specific git revision
-cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node-bin --rev <git-sha>
+cargo install --locked --git https://github.com/0xMiden/note-transport-service miden-note-transport-node --rev <git-sha>
 ```
 
 More information on the various `cargo install` options can be found

--- a/docs/src/operator/monitoring.md
+++ b/docs/src/operator/monitoring.md
@@ -80,7 +80,7 @@ The OpenTelemetry trace and metrics exporters are enabled by setting `OTEL_ENABL
 ```sh
 OTEL_ENABLED=true \
 OTEL_TRACES_ENDPOINT=http://localhost:4317 \
-miden-note-transport-node-bin
+miden-note-transport-node
 ```
 
 Further exporter behaviour can be configured using the standard OpenTelemetry environment variables as specified in the

--- a/docs/src/operator/usage.md
+++ b/docs/src/operator/usage.md
@@ -9,15 +9,15 @@ Start the node with the desired public gRPC server address.
 For example,
 
 ```sh
-miden-note-transport-node-bin \
+miden-note-transport-node \
   --host 0.0.0.0 \
   --port 57292 \
   --database-url mtln.db
 ```
 
 > [!NOTE]
-> `miden-note-transport-node-bin` provides default arguments aimed at development.
+> `miden-note-transport-node` provides default arguments aimed at development.
 
-Configuration is purely made using command line arguments. Run `miden-note-transport-node-bin --help` for available options.
+Configuration is purely made using command line arguments. Run `miden-note-transport-node --help` for available options.
 
 If using the provided Docker setup, see the [setup page](installation.md#docker-setup). Configure the node binary launch arguments accordingly before starting Docker containers.


### PR DESCRIPTION
This PR adds two GitHub Actions workflows:

- _build check_: this runs for the `main` and `next` branches on changes, plus on PRs, and makes sure the Docker image still builds correctly.
- _publish_: this workflow pushes a multi-arch Docker image for release tags. Triggered on `v*` tag pushes.

Closes issue #102 