### PR TITLE
feat: add gRPC reflection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,6 @@ dependencies = [
  "miette",
  "prost 0.14.4",
  "prost-types",
- "protox",
  "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
@@ -4004,11 +4003,11 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "tokio",
  "tonic 0.14.5",
  "tonic-health",
+ "tonic-reflection",
  "tonic-web",
  "tower",
  "tower-http",
@@ -1859,10 +1860,10 @@ name = "miden-note-transport-proto"
 version = "0.5.0-alpha.1"
 dependencies = [
  "fs-err",
+ "miden-note-transport-proto-build",
  "miette",
  "prost 0.14.3",
  "prost-types",
- "protox",
  "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
@@ -3909,6 +3910,20 @@ dependencies = [
  "syn 2.0.117",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.5",
+ "tonic-prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tonic = { default-features = false, features = ["codegen", "transport"], version
 tonic-health = { version = "0.14" }
 tonic-prost = { version = "0.14" }
 tonic-prost-build = { version = "0.14" }
+tonic-reflection = { version = "0.14" }
 tonic-web = { version = "0.14" }
 tower = { version = "0.5" }
 tower-http = { features = ["cors"], version = "0.6" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -28,12 +28,13 @@ miden-note-transport-proto = { workspace = true }
 miden-protocol = { features = ["testing"], workspace = true }
 
 # gRPC server and client
-tokio        = { workspace = true }
-tonic        = { default-features = true, workspace = true }
-tonic-health = { workspace = true }
-tonic-web    = { workspace = true }
-tower        = { features = ["timeout"], workspace = true }
-tower-http   = { features = ["cors"], workspace = true }
+tokio            = { workspace = true }
+tonic            = { default-features = true, workspace = true }
+tonic-health     = { workspace = true }
+tonic-reflection = { workspace = true }
+tonic-web        = { workspace = true }
+tower            = { features = ["timeout"], workspace = true }
+tower-http       = { features = ["cors"], workspace = true }
 
 # Protobuf
 prost-types = { workspace = true }

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use miden_note_transport_proto::FILE_DESCRIPTOR_SET;
 use miden_note_transport_proto::miden_note_transport::miden_note_transport_server::MidenNoteTransportServer;
 use miden_note_transport_proto::miden_note_transport::{
     FetchNotesRequest,
@@ -99,6 +100,14 @@ impl GrpcServer {
         let (health_reporter, health_svc) = tonic_health::server::health_reporter();
         health_reporter.set_serving::<MidenNoteTransportServer<Self>>().await;
 
+        let reflection_svc = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+            .build_v1()
+            .map_err(|e| {
+                crate::Error::Internal(format!("Failed to build reflection service: {e}"))
+            })?;
+
         let addr = format!("{}:{}", self.config.host, self.config.port)
             .parse::<SocketAddr>()
             .map_err(|e| crate::Error::Internal(format!("Invalid address: {e}")))?;
@@ -112,6 +121,7 @@ impl GrpcServer {
             .layer(GlobalConcurrencyLimitLayer::new(self.config.max_connections))
             .layer(TimeoutLayer::new(Duration::from_secs(self.config.request_timeout as u64)))
             .add_service(health_svc)
+            .add_service(reflection_svc)
             .add_service(self.into_service())
             .serve(addr)
             .await

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -20,7 +20,8 @@ tonic       = { features = ["codegen"], workspace = true }
 tonic-prost = { workspace = true }
 
 [build-dependencies]
-fs-err            = { workspace = true }
-miette            = { workspace = true }
-protox            = { workspace = true }
-tonic-prost-build = { workspace = true }
+fs-err                           = { workspace = true }
+miden-note-transport-proto-build = { workspace = true }
+miette                           = { workspace = true }
+prost                            = { workspace = true }
+tonic-prost-build                = { workspace = true }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -3,40 +3,31 @@ use std::path::PathBuf;
 
 use fs_err as fs;
 use miette::{Context, IntoDiagnostic};
-use protox::prost::Message;
+use prost::Message;
 
-const MNT_PROTO: &str = "miden_note_transport.proto";
 const MNT_DESCRIPTOR: &str = "miden_note_transport_file_descriptor.bin";
 
-/// Generates Rust protobuf bindings from .proto files.
+/// Writes the API descriptor to `OUT_DIR` and optionally regenerates the Rust bindings.
 ///
-/// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
-/// script on crates.io where repo-level .proto files are not available.
+/// Bindings are regenerated only if `BUILD_PROTO` is set to `1`; published builds use the
+/// descriptor supplied by the proto-build crate and the committed Rust bindings.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo::rerun-if-changed=../../proto/proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
+
+    let out =
+        env::var("OUT_DIR").expect("env::OUT_DIR is always set in build.rs when used with cargo");
+    let descriptor = miden_note_transport_proto_build::mnt_api_descriptor();
+    let descriptor_path = PathBuf::from(out).join(MNT_DESCRIPTOR);
+    fs::write(descriptor_path, descriptor.encode_to_vec())
+        .into_diagnostic()
+        .wrap_err("writing mnt file descriptor")?;
 
     if env::var("BUILD_PROTO").as_deref() != Ok("1") {
         return Ok(());
     }
 
-    let out =
-        env::var("OUT_DIR").expect("env::OUT_DIR is always set in build.rs when used with cargo");
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let proto_dir = workspace_root.join("proto").join("proto");
-    let includes = &[proto_dir];
-
-    let mnt_file_descriptor = protox::compile([MNT_PROTO], includes)?;
-    let mnt_path = PathBuf::from(&out).join(MNT_DESCRIPTOR);
-    fs::write(&mnt_path, mnt_file_descriptor.encode_to_vec())
-        .into_diagnostic()
-        .wrap_err("writing mnt file descriptor")?;
-
     // Generate the Rust bindings
-    let descriptor = mnt_file_descriptor;
-
     tonic_prost_build::configure()
         .out_dir("src/generated")
         .build_server(true)
@@ -60,7 +51,10 @@ fn generate_mod_rs(directory: impl AsRef<std::path::Path>) -> std::io::Result<()
     for entry in fs::read_dir(directory.as_ref())? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_file() && path.file_name().unwrap() != "mod.rs" {
+        if path.is_file()
+            && path.extension().is_some_and(|extension| extension == "rs")
+            && path.file_name().unwrap() != "mod.rs"
+        {
             let file_stem = path
                 .file_stem()
                 .and_then(|f| f.to_str())

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -5,6 +5,10 @@
 #[rustfmt::skip]
 pub mod generated;
 
+/// Encoded Protobuf file descriptor set for the Miden Note Transport API.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("miden_note_transport_file_descriptor");
+
 // RE-EXPORTS
 // ================================================================================================
 


### PR DESCRIPTION
## Summary

- add the tonic gRPC v1 reflection service
- expose descriptors for the note transport and health APIs
- register reflection alongside the existing gRPC and health services

Closes #103 