### PR TITLE
fix: exit non-zero when the server dies

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -78,7 +78,5 @@ async fn main() -> Result<()> {
 
     // Run Node
     let node = Node::init(config).await?;
-    node.entrypoint().await;
-
-    Ok(())
+    node.entrypoint().await
 }

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -52,12 +52,44 @@ impl Node {
     }
 
     /// Node running-task
-    pub async fn entrypoint(self) {
+    ///
+    /// Returns the error that brought the server down, so that the process can exit non-zero and
+    /// supervisors configured to restart on failure actually restart it.
+    pub async fn entrypoint(self) -> Result<()> {
         info!("Starting Miden Transport Node");
         tokio::spawn(self.maintenance.entrypoint());
 
-        if let Err(e) = self.grpc.serve().await {
-            error!("Server error: {e}");
-        }
+        self.grpc.serve().await.inspect_err(|e| error!("Server error: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    /// A fatal server error must reach the caller rather than being logged and swallowed,
+    /// otherwise the process exits 0 and `restart: on-failure` never fires.
+    #[tokio::test]
+    async fn entrypoint_returns_the_error_that_brought_the_server_down() {
+        // Hold the port so that the node's own bind is guaranteed to fail.
+        let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = occupied.local_addr().unwrap().port();
+
+        let config = NodeConfig {
+            grpc: GrpcServerConfig {
+                host: "127.0.0.1".into(),
+                port,
+                ..Default::default()
+            },
+            database: DatabaseConfig::default(),
+        };
+
+        let node = Node::init(config).await.unwrap();
+
+        let err = node.entrypoint().await.unwrap_err();
+
+        assert!(err.to_string().contains("Server error"), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
Closes #126

Draft while I wait to be assigned on the issue.

## Rationale

`entrypoint()` logged the error from `grpc.serve()` and returned `()`, and `main` then returned `Ok(())`. A bind failure or any other fatal transport error therefore produced a clean exit 0, which Docker `restart: on-failure` and systemd `Restart=on-failure` both read as success. The service stays down and the supervisor thinks it succeeded.

## Changes

`entrypoint()` returns the error to `main`, which propagates it so the process exits non-zero. The error is still logged on the way out.

## Tests

`entrypoint_returns_the_error_that_brought_the_server_down` binds a listener to a free port and holds it, so the node's own bind is guaranteed to fail, then asserts the error reaches the caller. I checked the failure is a genuine bind error rather than something incidental: it comes back as `Internal server error: Server error: transport error`.

## Checks

`cargo test -p miden-note-transport-node` passes, clippy is clean over the workspace, and `cargo fmt --check` with `configs/rustfmt.toml` reports nothing in the touched files.
