### PR TITLE
docs: correct the telemetry configuration in both doc trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Skip the changelog only when the PR contains no runtime-affecting changes
 
 ### Changes
 
-- Changed OpenTelemetry configuration: enable via `--enable-otel`/`--otel-endpoint` flags or the standard `OTEL_EXPORTER_OTLP_ENDPOINT`/`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env vars. The previous `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` vars are no longer read ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
+- Changed OpenTelemetry configuration: enable by setting the standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`/`OTEL_EXPORTER_OTLP_ENDPOINT` env vars. The previous `OTEL_ENABLED`/`OTEL_TRACES_ENDPOINT` vars are no longer read ([#80](https://github.com/0xMiden/note-transport-service/pull/80)).
 
 ## v0.4.0 (2026-06-08)
 

--- a/crates/node/src/logging.rs
+++ b/crates/node/src/logging.rs
@@ -93,7 +93,16 @@ pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
                 Ok(exporter) => {
                     Some(open_telemetry_layer(exporter, "miden-note-transport-node".to_string()))
                 },
-                Err(_) => None,
+                // The operator asked for export by configuring an endpoint, so silently running
+                // without traces would leave them staring at an empty dashboard.
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "OTLP endpoint is configured but the trace exporter could not be built; \
+                         continuing without trace export"
+                    );
+                    None
+                },
             }
         } else {
             None

--- a/docs/external/src/operators.md
+++ b/docs/external/src/operators.md
@@ -55,16 +55,15 @@ Telemetry is configured through environment variables:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `OTEL_ENABLED` | `false` | Enables OpenTelemetry export when set to `true`. |
-| `OTEL_TRACES_ENDPOINT` | `http://localhost:4317` | OTLP endpoint for trace and metric export. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | OTLP endpoint for trace and metric export. Setting it enables export. Takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OTLP endpoint used when the traces-specific variable is not set. Setting it enables export. |
 | `JSON_LOGGING` | `false` | Emits JSON logs when set to `true`. |
 | `RUST_LOG` | `INFO` | Standard Rust tracing filter. |
 
 Example:
 
 ```bash
-OTEL_ENABLED=true \
-OTEL_TRACES_ENDPOINT=http://otel-collector:4317 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
 JSON_LOGGING=true \
 RUST_LOG=INFO \
 miden-note-transport-node --host 0.0.0.0 --database-url /var/lib/miden-note-transport/node.db

--- a/docs/src/operator/monitoring.md
+++ b/docs/src/operator/monitoring.md
@@ -2,9 +2,10 @@
 
 We provide logging to `stdout` and an optional [OpenTelemetry](https://opentelemetry.io/) exporter for our metrics and traces.
 
-OpenTelemetry exporting can be enabled by setting the `OTEL_ENABLED=true` environment variable when operating
-the node. The OTLP endpoint (default `http://localhost:4317`) can be overridden with `OTEL_TRACES_ENDPOINT`, and
-structured JSON logging to `stdout` can be enabled with `JSON_LOGGING=true`.
+OpenTelemetry exporting is enabled by pointing the node at an OTLP endpoint with the standard
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable; the former takes
+precedence. There is no separate on/off switch — export is on when an endpoint is set and off when neither
+variable is set or both are empty. Structured JSON logging to `stdout` can be enabled with `JSON_LOGGING=true`.
 
 ## Metrics
 
@@ -75,13 +76,15 @@ export RUST_LOG=debug
 
 ## Configuration
 
-The OpenTelemetry trace and metrics exporters are enabled by setting `OTEL_ENABLED=true` when starting the node:
+The OpenTelemetry trace and metrics exporters are enabled by setting an OTLP endpoint when starting the node:
 
 ```sh
-OTEL_ENABLED=true \
-OTEL_TRACES_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
 miden-note-transport-node
 ```
+
+To point traces somewhere other than the general endpoint, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, which
+takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
 Further exporter behaviour can be configured using the standard OpenTelemetry environment variables as specified in the
 official [documents](https://opentelemetry.io/docs/specs/otel/protocol/exporter/).


### PR DESCRIPTION
Closes #134

Draft while I wait to be assigned on the issue.

## Rationale

Both operator doc trees documented `OTEL_ENABLED` and `OTEL_TRACES_ENDPOINT`, and the v0.4.1 changelog entry additionally claimed `--enable-otel`/`--otel-endpoint` CLI flags. None of the four exist. `TracingConfig::from_otel_env` reads only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT`, and the binary takes no telemetry flags at all. An operator following the published docs got no telemetry and no indication why.

## Changes

Rewrites `docs/src/operator/monitoring.md`, `docs/external/src/operators.md` and the v0.4.1 changelog entry to the variables actually read. The docs now also state that there is no separate on/off switch — export is on when an endpoint is set and off when neither variable is set — since that is the part the old `OTEL_ENABLED=true` framing got wrong conceptually, not just by name.

Also logs a warning when the trace exporter fails to build. That error was discarded at `logging.rs`, so a malformed endpoint disabled tracing silently. As the issue notes, that is the same empty dashboard reached by a second route, and it compounds the doc problem: an operator who fixes their variable names but fat-fingers the URL is back to guessing.

I grepped the repo afterwards for the old names; the only remaining mention is the historical changelog line saying they are no longer read, which is correct.

## Checks

Test suite passes and clippy is clean. The only code change is the added warning.
