### PR TITLE
fix(db): batch retention cleanup and set durability pragmas explicitly

### DIFF
--- a/crates/node/src/database/sqlite/connection_manager.rs
+++ b/crates/node/src/database/sqlite/connection_manager.rs
@@ -93,7 +93,30 @@ pub fn configure_connection_on_creation(
         .map_err(ConnectionManagerError::ConnectionParamSetup)?;
 
     // Set busy timeout to handle concurrent access (30 seconds)
+    //
+    // NOTE: this is longer than the gRPC request timeout, so a request that has already timed out
+    // can still occupy a blocking thread and a pool connection while it waits here. Aligning the
+    // two means threading the server config down to the pool; tracked in #132.
     diesel::sql_query("PRAGMA busy_timeout=30000")
+        .execute(conn)
+        .map_err(ConnectionManagerError::ConnectionParamSetup)?;
+
+    // Fsync the WAL on every commit.
+    //
+    // Between `send_note` and the recipient consuming it, this database is the only copy of a
+    // note in existence — there is no sender-side queue to replay from and no peer to re-fetch
+    // from. `NORMAL` would leave the last commits before a power loss or OS crash on the floor,
+    // which for this service means notes that were acknowledged and then silently lost. The
+    // per-commit fsync is the price of being the sole holder of the payload.
+    diesel::sql_query("PRAGMA synchronous=FULL")
+        .execute(conn)
+        .map_err(ConnectionManagerError::ConnectionParamSetup)?;
+
+    // Checkpoint the WAL every 1000 pages (~4 MB at the default page size).
+    //
+    // This is SQLite's own default, set explicitly so that the WAL growth characteristics are
+    // part of this configuration rather than whatever the linked libsqlite3 was built with.
+    diesel::sql_query("PRAGMA wal_autocheckpoint=1000")
         .execute(conn)
         .map_err(ConnectionManagerError::ConnectionParamSetup)?;
 

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -19,6 +19,14 @@ use models::{NewNote, Note};
 /// backlogged client paginates naturally by re-calling with the returned cursor.
 pub(crate) const FETCH_NOTES_BATCH_SIZE: i64 = 500;
 
+/// Maximum number of expired notes deleted per transaction by `cleanup_old_notes`.
+///
+/// Retention cleanup is a background job with no deadline, so the batch size trades total
+/// throughput for how long the writer lock is held in one go. 10k rows keeps a single batch to a
+/// few milliseconds even on a cold page cache, well inside the window in which a concurrent
+/// `store_note` will still complete.
+const CLEANUP_BATCH_SIZE: i64 = 10_000;
+
 /// Threshold above which a `fetch_notes` cursor is interpreted as a legacy
 /// microsecond-timestamp cursor from the pre-`seq` schema and reset to 0.
 ///
@@ -38,6 +46,60 @@ pub struct SqliteDatabase {
 }
 
 impl SqliteDatabase {
+    /// Delete every note created before `cutoff_timestamp`, `batch_size` rows per transaction.
+    ///
+    /// Deleting the whole expired set in one statement holds the writer lock for its entire
+    /// duration and grows the WAL by the size of the transaction. After downtime or a retention
+    /// change that set can be millions of rows, which is long enough to push concurrent
+    /// `store_note` calls past the busy timeout. Batching bounds both.
+    ///
+    /// Returns the total number of notes deleted.
+    async fn cleanup_notes_before(
+        &self,
+        cutoff_timestamp: i64,
+        batch_size: i64,
+    ) -> Result<u64, DatabaseError> {
+        let mut total_deleted: u64 = 0;
+
+        loop {
+            let deleted: i64 = self
+                .transact("cleanup old notes", move |conn| {
+                    use schema::notes::dsl::{created_at, notes, seq};
+
+                    // `DELETE ... LIMIT` needs SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which is not
+                    // enabled in every libsqlite3 build, so bound the batch by selecting primary
+                    // keys first. Oldest first, so a run interrupted part-way still makes forward
+                    // progress.
+                    let doomed = notes
+                        .select(seq)
+                        .filter(created_at.lt(cutoff_timestamp))
+                        .order(seq.asc())
+                        .limit(batch_size)
+                        .load::<i64>(conn)?;
+
+                    if doomed.is_empty() {
+                        return Ok(0);
+                    }
+
+                    let count = diesel::delete(notes.filter(seq.eq_any(doomed))).execute(conn)?;
+                    Ok(i64::try_from(count).unwrap_or(0))
+                })
+                .await?;
+
+            total_deleted = total_deleted.saturating_add(deleted.try_into().unwrap_or(0));
+
+            // A short batch means the expired set is exhausted.
+            if deleted < batch_size {
+                break;
+            }
+
+            // Give writers a chance at the lock between batches.
+            tokio::task::yield_now().await;
+        }
+
+        Ok(total_deleted)
+    }
+
     /// Execute a query within a transaction
     async fn transact<R, Q, M>(&self, msg: M, query: Q) -> Result<R, DatabaseError>
     where
@@ -233,18 +295,9 @@ impl DatabaseBackend for SqliteDatabase {
 
     async fn cleanup_old_notes(&self, retention_days: u32) -> Result<u64, DatabaseError> {
         let cutoff_date = Utc::now() - chrono::Duration::days(i64::from(retention_days));
-        let cutoff_timestamp = cutoff_date.timestamp_micros();
 
-        let deleted_count: i64 = self
-            .transact("cleanup old notes", move |conn| {
-                use schema::notes::dsl::{created_at, notes};
-                let count =
-                    diesel::delete(notes.filter(created_at.lt(cutoff_timestamp))).execute(conn)?;
-                Ok(i64::try_from(count).unwrap_or(0))
-            })
-            .await?;
-
-        Ok(deleted_count.try_into().unwrap_or(0))
+        self.cleanup_notes_before(cutoff_date.timestamp_micros(), CLEANUP_BATCH_SIZE)
+            .await
     }
 
     async fn note_exists(&self, note_id: NoteId) -> Result<bool, DatabaseError> {
@@ -258,5 +311,103 @@ impl DatabaseBackend for SqliteDatabase {
             .await?;
 
         Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Metrics;
+    use crate::test_utils::test_note_header;
+
+    /// Store `count` notes, all stamped at `created_at`.
+    async fn store_notes_at(db: &SqliteDatabase, count: usize, created_at: chrono::DateTime<Utc>) {
+        for _ in 0..count {
+            let note = StoredNote {
+                header: test_note_header(),
+                details: vec![1, 2, 3],
+                created_at,
+                seq: 0,
+                after_block_num: None,
+            };
+            db.store_note(&note).await.unwrap();
+        }
+    }
+
+    async fn test_db() -> SqliteDatabase {
+        SqliteDatabase::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap()
+    }
+
+    /// The expired set is deleted in full even when it spans many batches, and the loop
+    /// terminates rather than spinning on the final short batch.
+    #[tokio::test]
+    async fn cleanup_deletes_every_expired_note_across_batches() {
+        let db = test_db().await;
+        let old = Utc::now() - chrono::Duration::days(60);
+
+        store_notes_at(&db, 7, old).await;
+
+        // A batch size well below the row count forces several passes, with the last one short.
+        let deleted = db.cleanup_notes_before(Utc::now().timestamp_micros(), 2).await.unwrap();
+
+        assert_eq!(deleted, 7);
+        assert_eq!(db.get_stats().await.unwrap().0, 0);
+    }
+
+    /// Only notes older than the cutoff are deleted; the batching must not run past it.
+    #[tokio::test]
+    async fn cleanup_keeps_notes_newer_than_the_cutoff() {
+        let db = test_db().await;
+        let old = Utc::now() - chrono::Duration::days(60);
+        let recent = Utc::now();
+
+        store_notes_at(&db, 5, old).await;
+        store_notes_at(&db, 3, recent).await;
+
+        let cutoff = (Utc::now() - chrono::Duration::days(30)).timestamp_micros();
+        let deleted = db.cleanup_notes_before(cutoff, 2).await.unwrap();
+
+        assert_eq!(deleted, 5);
+        assert_eq!(db.get_stats().await.unwrap().0, 3);
+    }
+
+    /// Durability must not depend on how the linked libsqlite3 was built, so the pragmas are set
+    /// explicitly on every connection. `synchronous=FULL` is 2.
+    #[tokio::test]
+    async fn connections_are_opened_with_the_configured_durability_pragmas() {
+        #[derive(QueryableByName)]
+        struct PragmaValue {
+            #[diesel(sql_type = diesel::sql_types::Integer)]
+            value: i32,
+        }
+
+        let db = test_db().await;
+
+        let synchronous = db
+            .query("read synchronous pragma", |conn| {
+                Ok(diesel::sql_query("SELECT synchronous AS value FROM pragma_synchronous")
+                    .load::<PragmaValue>(conn)?
+                    .first()
+                    .map(|row| row.value)
+                    .unwrap_or_default())
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(synchronous, 2, "expected PRAGMA synchronous=FULL");
+    }
+
+    /// Nothing to delete must be one empty pass, not an error and not a loop.
+    #[tokio::test]
+    async fn cleanup_on_an_empty_expired_set_is_a_no_op() {
+        let db = test_db().await;
+        store_notes_at(&db, 3, Utc::now()).await;
+
+        let cutoff = (Utc::now() - chrono::Duration::days(30)).timestamp_micros();
+
+        assert_eq!(db.cleanup_notes_before(cutoff, 2).await.unwrap(), 0);
+        assert_eq!(db.get_stats().await.unwrap().0, 3);
     }
 }


### PR DESCRIPTION
Closes #132

Draft while I wait to be assigned on the issue.

## (a) Unbounded DELETE

Retention cleanup ran a single `DELETE ... WHERE created_at < cutoff` with no bound. After downtime or a retention-config change that can be millions of rows in one transaction, holding the writer lock for the whole run — long enough to push concurrent `store_note` calls past the 30s busy timeout and back to clients as errors — while growing the WAL by the size of the transaction.

Cleanup now deletes in batches of 10k, oldest first, yielding between batches so writers can take the lock.

The batch is bounded by selecting primary keys in a subquery rather than `DELETE ... LIMIT`, which needs a libsqlite3 built with `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` and is not available everywhere. Oldest-first means a run interrupted part-way still made forward progress rather than redoing the same rows.

## (b) Implicit durability

Only `journal_mode`, `foreign_keys` and `busy_timeout` were set, so durability was whatever the linked libsqlite3 was built with. Now explicit:

- `synchronous=FULL`, not the usual WAL choice of `NORMAL`. Between `send_note` and the recipient consuming it, this database is the only copy of a note in existence — there is no sender-side queue to replay from and no peer to re-fetch from. `NORMAL` would leave the last commits before a power loss on the floor, which here means notes that were acknowledged and then silently lost. The per-commit fsync is the price of being the sole holder of the payload. If the recipient-side retry story is stronger than I am assuming, this is a one-word change.
- `wal_autocheckpoint=1000`, which is SQLite's own default, set explicitly so WAL growth is part of this configuration rather than of the build.

## Tests

The batch size is a parameter of a private helper, so the multi-batch path is testable without inserting 10k rows:

- `cleanup_deletes_every_expired_note_across_batches` — 7 rows at batch size 2, so several passes with a short final one; asserts the loop terminates and deletes everything.
- `cleanup_keeps_notes_newer_than_the_cutoff` — batching must not run past the cutoff.
- `cleanup_on_an_empty_expired_set_is_a_no_op`.
- `connections_are_opened_with_the_configured_durability_pragmas` reads `PRAGMA synchronous` back through the pool. I checked it is not vacuous: flipping the pragma to `NORMAL` fails it with `left: 1, right: 2`.

## Not addressed

The `busy_timeout` (30s) vs request timeout (4s) mismatch from the "Also" paragraph. A timed-out request can still hold a blocking thread and a pool connection for up to 30s. Aligning them means threading `GrpcServerConfig` down into the connection manager, which is a wiring change rather than a pragma change, so I left it for you to direct — with a note at the pragma site pointing back at this issue.

## Checks

Full test suite passes, clippy is clean over the workspace, and `cargo fmt --check` with `configs/rustfmt.toml` reports nothing in the touched files.
