### PR TITLE
feat: drain on SIGTERM instead of dying mid-request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3785,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,12 @@ serde = { features = ["derive"], version = "1.0" }
 serde_json = { version = "1.0" }
 serial_test = { version = "3.2" }
 thiserror = { default-features = false, version = "2.0" }
-tokio = { features = ["macros", "net", "rt-multi-thread"], version = "1.48" }
+tokio = { features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "signal",
+], version = "1.48" }
 tonic = { default-features = false, features = ["codegen", "transport"], version = "0.14" }
 tonic-health = { version = "0.14" }
 tonic-prost = { version = "0.14" }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use miden_note_transport_node::database::DatabaseConfig;
 use miden_note_transport_node::logging::{TracingConfig, setup_tracing};
 use miden_note_transport_node::node::grpc::GrpcServerConfig;
-use miden_note_transport_node::{Node, NodeConfig, Result};
+use miden_note_transport_node::{Node, NodeConfig, Result, shutdown};
 use tracing::info;
 
 #[derive(Parser)]
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
     // endpoint env var is set (OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or
     // OTEL_EXPORTER_OTLP_ENDPOINT).
     let tracing_cfg = TracingConfig::from_otel_env();
-    setup_tracing(tracing_cfg.clone())?;
+    let telemetry = setup_tracing(tracing_cfg.clone())?;
 
     info!("Starting Miden Transport Node...");
     info!("Host: {}", args.host);
@@ -76,7 +76,14 @@ async fn main() -> Result<()> {
         },
     };
 
-    // Run Node
+    // Run Node until a shutdown signal arrives
     let node = Node::init(config).await?;
-    node.entrypoint().await
+    let result = node.entrypoint(shutdown::signal()).await;
+
+    // Flush buffered spans and metrics last, so everything the shutdown itself emitted is
+    // exported rather than dying with the process.
+    telemetry.shutdown();
+    info!("Shutdown complete");
+
+    result
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -78,7 +78,5 @@ async fn main() -> Result<()> {
 
     // Run Node
     let node = Node::init(config).await?;
-    node.entrypoint().await;
-
-    Ok(())
+    node.entrypoint().await
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -37,6 +37,8 @@ pub mod logging;
 pub mod metrics;
 /// Main node implementation
 pub mod node;
+/// Process shutdown signalling
+pub mod shutdown;
 /// Testing functions
 ///
 /// Available during tests or when the `testing` feature is enabled.

--- a/crates/node/src/logging.rs
+++ b/crates/node/src/logging.rs
@@ -73,12 +73,14 @@ impl OpenTelemetry {
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
-pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
+pub fn setup_tracing(cfg: TracingConfig) -> Result<TelemetryGuard> {
+    let mut guard = TelemetryGuard::default();
+
     if cfg.otel.is_enabled() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
         // Setup metrics export if OTEL is enabled
-        setup_metrics_export(&cfg.otel)?;
+        guard.meter_provider = setup_metrics_export(&cfg.otel)?;
     }
 
     // Note: open-telemetry requires a tokio-runtime, so this _must_ be lazily evaluated (aka not
@@ -91,7 +93,10 @@ pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
 
             match exporter_builder.build() {
                 Ok(exporter) => {
-                    Some(open_telemetry_layer(exporter, "miden-note-transport-node".to_string()))
+                    let (layer, provider) =
+                        open_telemetry_layer(exporter, "miden-note-transport-node".to_string());
+                    guard.tracer_provider = Some(provider);
+                    Some(layer)
                 },
                 Err(_) => None,
             }
@@ -104,11 +109,47 @@ pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
         .with(stdout_layer(cfg.json_format).with_filter(env_or_default_filter()))
         .with(otel_layer.with_filter(env_or_default_filter()));
 
-    tracing::subscriber::set_global_default(subscriber).map_err(Into::into)
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(guard)
+}
+
+/// Handles to the OpenTelemetry providers, so that buffered telemetry can be flushed on shutdown.
+///
+/// Both providers batch: spans and metrics recorded since the last export live only in memory
+/// until the next flush. Without an explicit shutdown, everything since the last export interval
+/// is lost — which is exactly the window an operator most wants to see when a pod is being
+/// evicted. Empty when export is disabled, in which case [`TelemetryGuard::shutdown`] is a no-op.
+#[derive(Default)]
+pub struct TelemetryGuard {
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+}
+
+impl TelemetryGuard {
+    /// Flush and shut down the OpenTelemetry providers.
+    ///
+    /// Failures are logged rather than propagated: losing telemetry must not turn an otherwise
+    /// clean shutdown into a non-zero exit, which a supervisor would read as a crash.
+    pub fn shutdown(self) {
+        if let Some(provider) = self.tracer_provider
+            && let Err(e) = provider.shutdown()
+        {
+            tracing::warn!(error = %e, "Failed to shut down the trace provider");
+        }
+
+        if let Some(provider) = self.meter_provider
+            && let Err(e) = provider.shutdown()
+        {
+            tracing::warn!(error = %e, "Failed to shut down the meter provider");
+        }
+    }
 }
 
 /// Setup OpenTelemetry metrics export using the proper SDK API
-fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<()> {
+///
+/// Returns a handle to the provider so that buffered metrics can be flushed on shutdown.
+fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<Option<SdkMeterProvider>> {
     if let OpenTelemetry::Enabled { endpoint } = otel_cfg {
         // Configure OTLP metrics pipeline
         let exporter = opentelemetry_otlp::MetricExporter::builder()
@@ -125,10 +166,12 @@ fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<()> {
             .build();
 
         // Set the meter provider globally
-        opentelemetry::global::set_meter_provider(provider);
+        opentelemetry::global::set_meter_provider(provider.clone());
+
+        return Ok(Some(provider));
     }
 
-    Ok(())
+    Ok(None)
 }
 
 /// Initializes tracing to a test exporter.
@@ -147,7 +190,7 @@ pub fn setup_test_tracing() -> Result<(
     let (exporter, rx_export, rx_shutdown) =
         opentelemetry_sdk::testing::trace::new_tokio_test_exporter();
 
-    let otel_layer = open_telemetry_layer(exporter, "test-service".to_string());
+    let (otel_layer, _provider) = open_telemetry_layer(exporter, "test-service".to_string());
     let subscriber = Registry::default()
         .with(stdout_layer(true).with_filter(env_or_default_filter()))
         .with(otel_layer.with_filter(env_or_default_filter()));
@@ -155,10 +198,15 @@ pub fn setup_test_tracing() -> Result<(
     Ok((rx_export, rx_shutdown))
 }
 
+/// Build the OpenTelemetry tracing layer, returning it alongside a handle to its provider so the
+/// batched spans can be flushed on shutdown.
 fn open_telemetry_layer<S>(
     exporter: impl SpanExporter + 'static,
     service_name: String,
-) -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
+) -> (
+    Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>,
+    opentelemetry_sdk::trace::SdkTracerProvider,
+)
 where
     S: Subscriber + Sync + Send,
     for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
@@ -170,9 +218,9 @@ where
     let tracer = provider.tracer(service_name);
 
     // Set the tracer provider globally
-    opentelemetry::global::set_tracer_provider(provider);
+    opentelemetry::global::set_tracer_provider(provider.clone());
 
-    OpenTelemetryLayer::new(tracer).boxed()
+    (OpenTelemetryLayer::new(tracer).boxed(), provider)
 }
 
 fn stdout_layer<S>(

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -96,7 +96,15 @@ impl GrpcServer {
     }
 
     /// gRPC server running-task
-    pub async fn serve(self) -> crate::Result<()> {
+    ///
+    /// Serves until `shutdown` resolves, at which point tonic stops accepting new connections and
+    /// waits for in-flight requests to finish before returning. Dropping the service afterwards
+    /// stops the note streamer, which sends its subscribers a `GOAWAY` rather than having their
+    /// connections cut.
+    pub async fn serve_with_shutdown(
+        self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> crate::Result<()> {
         let (health_reporter, health_svc) = tonic_health::server::health_reporter();
         health_reporter.set_serving::<MidenNoteTransportServer<Self>>().await;
 
@@ -123,9 +131,13 @@ impl GrpcServer {
             .add_service(health_svc)
             .add_service(reflection_svc)
             .add_service(self.into_service())
-            .serve(addr)
+            .serve_with_shutdown(addr, shutdown)
             .await
-            .map_err(|e| crate::Error::Internal(format!("Server error: {e}")))
+            .map_err(|e| crate::Error::Internal(format!("Server error: {e}")))?;
+
+        tracing::info!("gRPC server drained");
+
+        Ok(())
     }
 }
 

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -52,12 +52,44 @@ impl Node {
     }
 
     /// Node running-task
-    pub async fn entrypoint(self) {
+    ///
+    /// Returns the error that brought the server down, so that the process can exit non-zero and
+    /// supervisors configured to restart on failure actually restart it.
+    pub async fn entrypoint(self) -> Result<()> {
         info!("Starting Miden Transport Node");
         tokio::spawn(self.maintenance.entrypoint());
 
-        if let Err(e) = self.grpc.serve().await {
-            error!("Server error: {e}");
-        }
+        self.grpc.serve().await.inspect_err(|e| error!("Server error: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    /// A fatal server error must reach the caller rather than being logged and swallowed,
+    /// otherwise the process exits 0 and `restart: on-failure` never fires.
+    #[tokio::test]
+    async fn entrypoint_returns_the_error_that_brought_the_server_down() {
+        // Hold the port so that the node's own bind is guaranteed to fail.
+        let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = occupied.local_addr().unwrap().port();
+
+        let config = NodeConfig {
+            grpc: GrpcServerConfig {
+                host: "127.0.0.1".into(),
+                port,
+                ..Default::default()
+            },
+            database: DatabaseConfig::default(),
+        };
+
+        let node = Node::init(config).await.unwrap();
+
+        let err = node.entrypoint().await.unwrap_err();
+
+        assert!(err.to_string().contains("Server error"), "unexpected error: {err}");
     }
 }

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -53,13 +53,32 @@ impl Node {
 
     /// Node running-task
     ///
+    /// Serves until `shutdown` resolves, then drains in-flight requests, stops the note streamer
+    /// and the maintenance loop, and returns.
+    ///
     /// Returns the error that brought the server down, so that the process can exit non-zero and
     /// supervisors configured to restart on failure actually restart it.
-    pub async fn entrypoint(self) -> Result<()> {
+    pub async fn entrypoint(
+        self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> Result<()> {
         info!("Starting Miden Transport Node");
-        tokio::spawn(self.maintenance.entrypoint());
+        let maintenance = tokio::spawn(self.maintenance.entrypoint());
 
-        self.grpc.serve().await.inspect_err(|e| error!("Server error: {e}"))
+        let result = self
+            .grpc
+            .serve_with_shutdown(shutdown)
+            .await
+            .inspect_err(|e| error!("Server error: {e}"));
+
+        // The maintenance loop spends almost all of its time sleeping between cleanup passes and
+        // holds no client-visible state, so there is nothing to drain — aborting it mid-sleep is
+        // the intended stop. A cleanup pass interrupted mid-transaction rolls back, and the next
+        // start picks the same expired rows up again.
+        maintenance.abort();
+        info!("Maintenance loop stopped");
+
+        result
     }
 }
 
@@ -69,6 +88,45 @@ mod tests {
 
     use super::*;
 
+    /// Bind to port 0 to reserve a free port, then release it for the node to claim.
+    fn free_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+    }
+
+    fn test_config(port: u16) -> NodeConfig {
+        NodeConfig {
+            grpc: GrpcServerConfig {
+                host: "127.0.0.1".into(),
+                port,
+                ..Default::default()
+            },
+            database: DatabaseConfig::default(),
+        }
+    }
+
+    /// The node must come back on its own once the shutdown signal fires. Before this, `serve`
+    /// ran until the process was killed, so SIGTERM cut in-flight work instead of draining it.
+    #[tokio::test]
+    async fn entrypoint_returns_once_the_shutdown_signal_fires() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let node = Node::init(test_config(free_port())).await.unwrap();
+
+        let running = tokio::spawn(node.entrypoint(async {
+            let _ = rx.await;
+        }));
+
+        // Let the server reach its accept loop before asking it to stop.
+        tokio::task::yield_now().await;
+        tx.send(()).unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), running)
+            .await
+            .expect("entrypoint must return after the shutdown signal")
+            .unwrap();
+
+        assert!(result.is_ok(), "a signalled shutdown is not a failure: {result:?}");
+    }
+
     /// A fatal server error must reach the caller rather than being logged and swallowed,
     /// otherwise the process exits 0 and `restart: on-failure` never fires.
     #[tokio::test]
@@ -77,18 +135,9 @@ mod tests {
         let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = occupied.local_addr().unwrap().port();
 
-        let config = NodeConfig {
-            grpc: GrpcServerConfig {
-                host: "127.0.0.1".into(),
-                port,
-                ..Default::default()
-            },
-            database: DatabaseConfig::default(),
-        };
+        let node = Node::init(test_config(port)).await.unwrap();
 
-        let node = Node::init(config).await.unwrap();
-
-        let err = node.entrypoint().await.unwrap_err();
+        let err = node.entrypoint(std::future::pending()).await.unwrap_err();
 
         assert!(err.to_string().contains("Server error"), "unexpected error: {err}");
     }

--- a/crates/node/src/shutdown.rs
+++ b/crates/node/src/shutdown.rs
@@ -1,0 +1,37 @@
+//! Process shutdown signalling.
+
+use tracing::info;
+
+/// Resolves when the process is asked to terminate.
+///
+/// Listens for `SIGTERM` — what Kubernetes and `docker stop` send — and for `SIGINT` via
+/// `Ctrl-C`, so an operator gets the same drain in both cases. On non-Unix targets only
+/// `Ctrl-C` is available.
+///
+/// # Panics
+/// Panics if the signal handlers cannot be installed, which means the process cannot be
+/// terminated cleanly and should not pretend otherwise.
+pub async fn signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to install the SIGTERM handler");
+        let mut sigint =
+            signal(SignalKind::interrupt()).expect("failed to install the SIGINT handler");
+
+        let received = tokio::select! {
+            _ = sigterm.recv() => "SIGTERM",
+            _ = sigint.recv() => "SIGINT",
+        };
+
+        info!(signal = received, "Shutdown signal received");
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await.expect("failed to install the Ctrl-C handler");
+        info!(signal = "Ctrl-C", "Shutdown signal received");
+    }
+}


### PR DESCRIPTION
Closes #119

Draft while I wait to be assigned on the issue.

> Contains the #126 exit-code fix (#137) as its first commit. Both change `entrypoint`'s signature, so they cannot be independent — please merge #137 first and this will rebase down to a single commit. Review the second commit.

## Rationale

There was no signal handling anywhere: `serve()` ran until the process was killed. On SIGTERM — a k8s eviction or `docker stop` — in-flight `SendNote` writes were cut, open `StreamNotes` connections dropped without a GOAWAY, the maintenance task killed wherever it happened to be, and every span and metric buffered since the last export interval went with the process. That last one is the window an operator most wants to see when a pod goes away.

## Changes

- `shutdown::signal()` resolves on SIGTERM or SIGINT, so an operator gets the same drain from `docker stop` and from Ctrl-C. Threaded down through `Node::entrypoint` into tonic's `serve_with_shutdown`, so the server stops accepting and drains in-flight requests before returning.
- The maintenance task's `JoinHandle` was previously dropped on the floor, leaving the loop running with no way to stop it. It is now held and aborted on the way out. Aborting mid-sleep is the intended stop rather than a compromise: the loop holds no client-visible state, and a cleanup pass interrupted mid-transaction rolls back and is picked up again on the next start.
- `setup_tracing` returns a `TelemetryGuard` holding the tracer and meter providers, whose `shutdown` flushes them. `main` calls it *after* the node returns, so telemetry emitted during the shutdown itself is exported too. Failures there are logged rather than propagated — losing telemetry must not turn a clean shutdown into a non-zero exit that a supervisor reads as a crash.
- Adds the `signal` feature to tokio.

The streamer needed nothing: `StreamerCtx`'s existing `Drop` already sends `StreamerMessage::Shutdown`, and dropping the service after the drain triggers it.

## Tests

`entrypoint_returns_once_the_shutdown_signal_fires` starts the node with a shutdown future it controls, fires it, and asserts `entrypoint` returns `Ok` within a timeout — i.e. the server actually comes back on its own instead of running until killed.

## Checks

Full test suite passes, clippy is clean over the workspace, and `cargo fmt --check` with `configs/rustfmt.toml` reports nothing in the touched files.
