### PR TITLE
feat: keep the reported health status truthful

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3785,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,12 @@ serde = { features = ["derive"], version = "1.0" }
 serde_json = { version = "1.0" }
 serial_test = { version = "3.2" }
 thiserror = { default-features = false, version = "2.0" }
-tokio = { features = ["macros", "net", "rt-multi-thread"], version = "1.48" }
+tokio = { features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "signal",
+], version = "1.48" }
 tonic = { default-features = false, features = ["codegen", "transport"], version = "0.14" }
 tonic-health = { version = "0.14" }
 tonic-prost = { version = "0.14" }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use miden_note_transport_node::database::DatabaseConfig;
 use miden_note_transport_node::logging::{TracingConfig, setup_tracing};
 use miden_note_transport_node::node::grpc::GrpcServerConfig;
-use miden_note_transport_node::{Node, NodeConfig, Result};
+use miden_note_transport_node::{Node, NodeConfig, Result, shutdown};
 use tracing::info;
 
 #[derive(Parser)]
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
     // endpoint env var is set (OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or
     // OTEL_EXPORTER_OTLP_ENDPOINT).
     let tracing_cfg = TracingConfig::from_otel_env();
-    setup_tracing(tracing_cfg.clone())?;
+    let telemetry = setup_tracing(tracing_cfg.clone())?;
 
     info!("Starting Miden Transport Node...");
     info!("Host: {}", args.host);
@@ -76,7 +76,14 @@ async fn main() -> Result<()> {
         },
     };
 
-    // Run Node
+    // Run Node until a shutdown signal arrives
     let node = Node::init(config).await?;
-    node.entrypoint().await
+    let result = node.entrypoint(shutdown::signal()).await;
+
+    // Flush buffered spans and metrics last, so everything the shutdown itself emitted is
+    // exported rather than dying with the process.
+    telemetry.shutdown();
+    info!("Shutdown complete");
+
+    result
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -78,7 +78,5 @@ async fn main() -> Result<()> {
 
     // Run Node
     let node = Node::init(config).await?;
-    node.entrypoint().await;
-
-    Ok(())
+    node.entrypoint().await
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use clap::Parser;
 use miden_note_transport_node::database::DatabaseConfig;
 use miden_note_transport_node::logging::{TracingConfig, setup_tracing};
@@ -36,6 +38,13 @@ struct Args {
     /// Connection timeout in seconds
     #[arg(long, default_value = "4")]
     request_timeout: usize,
+
+    /// Seconds to keep serving after reporting `NOT_SERVING` on shutdown
+    ///
+    /// Should cover at least one health-check interval of whatever load balancer fronts the
+    /// service, so it stops routing here before the node stops accepting. 0 drains immediately.
+    #[arg(long, default_value = "12")]
+    shutdown_grace_secs: u64,
 }
 
 #[tokio::main]
@@ -69,6 +78,7 @@ async fn main() -> Result<()> {
             max_note_size: args.max_note_size,
             max_connections: args.max_connections,
             request_timeout: args.request_timeout,
+            shutdown_grace: Duration::from_secs(args.shutdown_grace_secs),
         },
         database: DatabaseConfig {
             url: args.database_url,

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -48,6 +48,12 @@ pub trait DatabaseBackend: Send + Sync {
 
     /// Check if a note exists
     async fn note_exists(&self, note_id: NoteId) -> Result<bool, DatabaseError>;
+
+    /// Check that the database is reachable and can serve queries
+    ///
+    /// Takes a pool connection and runs a trivial statement, so it fails when the pool is
+    /// exhausted, the file has gone away, or the database is otherwise wedged.
+    async fn health_check(&self) -> Result<(), DatabaseError>;
 }
 
 /// Database manager for the transport layer
@@ -120,6 +126,11 @@ impl Database {
     /// Check if a note exists
     pub async fn note_exists(&self, note_id: NoteId) -> Result<bool, DatabaseError> {
         self.backend.note_exists(note_id).await
+    }
+
+    /// Check that the database is reachable and can serve queries
+    pub async fn health_check(&self) -> Result<(), DatabaseError> {
+        self.backend.health_check().await
     }
 }
 

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -247,6 +247,14 @@ impl DatabaseBackend for SqliteDatabase {
         Ok(deleted_count.try_into().unwrap_or(0))
     }
 
+    async fn health_check(&self) -> Result<(), DatabaseError> {
+        self.query("health check", |conn| {
+            diesel::sql_query("SELECT 1").execute(conn)?;
+            Ok(())
+        })
+        .await
+    }
+
     async fn note_exists(&self, note_id: NoteId) -> Result<bool, DatabaseError> {
         let count: i64 = self
             .query("check note existence", move |conn| {
@@ -258,5 +266,38 @@ impl DatabaseBackend for SqliteDatabase {
             .await?;
 
         Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Metrics;
+
+    async fn test_db() -> SqliteDatabase {
+        SqliteDatabase::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .unwrap()
+    }
+
+    /// The probe behind the gRPC health status must succeed while the database can serve queries.
+    #[tokio::test]
+    async fn health_check_passes_on_a_reachable_database() {
+        let db = test_db().await;
+
+        assert!(db.health_check().await.is_ok());
+    }
+
+    /// It must fail when the pool can no longer hand out connections. This is the case that used
+    /// to go unnoticed: the health status was set once at startup, so an exhausted pool or a
+    /// wedged database still advertised the node as SERVING.
+    #[tokio::test]
+    async fn health_check_fails_when_the_pool_cannot_serve() {
+        let db = test_db().await;
+        assert!(db.health_check().await.is_ok());
+
+        db.pool.close();
+
+        assert!(db.health_check().await.is_err(), "a closed pool must fail the health check");
     }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -37,6 +37,8 @@ pub mod logging;
 pub mod metrics;
 /// Main node implementation
 pub mod node;
+/// Process shutdown signalling
+pub mod shutdown;
 /// Testing functions
 ///
 /// Available during tests or when the `testing` feature is enabled.

--- a/crates/node/src/logging.rs
+++ b/crates/node/src/logging.rs
@@ -73,12 +73,14 @@ impl OpenTelemetry {
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
-pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
+pub fn setup_tracing(cfg: TracingConfig) -> Result<TelemetryGuard> {
+    let mut guard = TelemetryGuard::default();
+
     if cfg.otel.is_enabled() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
         // Setup metrics export if OTEL is enabled
-        setup_metrics_export(&cfg.otel)?;
+        guard.meter_provider = setup_metrics_export(&cfg.otel)?;
     }
 
     // Note: open-telemetry requires a tokio-runtime, so this _must_ be lazily evaluated (aka not
@@ -91,7 +93,10 @@ pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
 
             match exporter_builder.build() {
                 Ok(exporter) => {
-                    Some(open_telemetry_layer(exporter, "miden-note-transport-node".to_string()))
+                    let (layer, provider) =
+                        open_telemetry_layer(exporter, "miden-note-transport-node".to_string());
+                    guard.tracer_provider = Some(provider);
+                    Some(layer)
                 },
                 Err(_) => None,
             }
@@ -104,11 +109,47 @@ pub fn setup_tracing(cfg: TracingConfig) -> Result<()> {
         .with(stdout_layer(cfg.json_format).with_filter(env_or_default_filter()))
         .with(otel_layer.with_filter(env_or_default_filter()));
 
-    tracing::subscriber::set_global_default(subscriber).map_err(Into::into)
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(guard)
+}
+
+/// Handles to the OpenTelemetry providers, so that buffered telemetry can be flushed on shutdown.
+///
+/// Both providers batch: spans and metrics recorded since the last export live only in memory
+/// until the next flush. Without an explicit shutdown, everything since the last export interval
+/// is lost — which is exactly the window an operator most wants to see when a pod is being
+/// evicted. Empty when export is disabled, in which case [`TelemetryGuard::shutdown`] is a no-op.
+#[derive(Default)]
+pub struct TelemetryGuard {
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+}
+
+impl TelemetryGuard {
+    /// Flush and shut down the OpenTelemetry providers.
+    ///
+    /// Failures are logged rather than propagated: losing telemetry must not turn an otherwise
+    /// clean shutdown into a non-zero exit, which a supervisor would read as a crash.
+    pub fn shutdown(self) {
+        if let Some(provider) = self.tracer_provider
+            && let Err(e) = provider.shutdown()
+        {
+            tracing::warn!(error = %e, "Failed to shut down the trace provider");
+        }
+
+        if let Some(provider) = self.meter_provider
+            && let Err(e) = provider.shutdown()
+        {
+            tracing::warn!(error = %e, "Failed to shut down the meter provider");
+        }
+    }
 }
 
 /// Setup OpenTelemetry metrics export using the proper SDK API
-fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<()> {
+///
+/// Returns a handle to the provider so that buffered metrics can be flushed on shutdown.
+fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<Option<SdkMeterProvider>> {
     if let OpenTelemetry::Enabled { endpoint } = otel_cfg {
         // Configure OTLP metrics pipeline
         let exporter = opentelemetry_otlp::MetricExporter::builder()
@@ -125,10 +166,12 @@ fn setup_metrics_export(otel_cfg: &OpenTelemetry) -> Result<()> {
             .build();
 
         // Set the meter provider globally
-        opentelemetry::global::set_meter_provider(provider);
+        opentelemetry::global::set_meter_provider(provider.clone());
+
+        return Ok(Some(provider));
     }
 
-    Ok(())
+    Ok(None)
 }
 
 /// Initializes tracing to a test exporter.
@@ -147,7 +190,7 @@ pub fn setup_test_tracing() -> Result<(
     let (exporter, rx_export, rx_shutdown) =
         opentelemetry_sdk::testing::trace::new_tokio_test_exporter();
 
-    let otel_layer = open_telemetry_layer(exporter, "test-service".to_string());
+    let (otel_layer, _provider) = open_telemetry_layer(exporter, "test-service".to_string());
     let subscriber = Registry::default()
         .with(stdout_layer(true).with_filter(env_or_default_filter()))
         .with(otel_layer.with_filter(env_or_default_filter()));
@@ -155,10 +198,15 @@ pub fn setup_test_tracing() -> Result<(
     Ok((rx_export, rx_shutdown))
 }
 
+/// Build the OpenTelemetry tracing layer, returning it alongside a handle to its provider so the
+/// batched spans can be flushed on shutdown.
 fn open_telemetry_layer<S>(
     exporter: impl SpanExporter + 'static,
     service_name: String,
-) -> Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>
+) -> (
+    Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>,
+    opentelemetry_sdk::trace::SdkTracerProvider,
+)
 where
     S: Subscriber + Sync + Send,
     for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
@@ -170,9 +218,9 @@ where
     let tracer = provider.tracer(service_name);
 
     // Set the tracer provider globally
-    opentelemetry::global::set_tracer_provider(provider);
+    opentelemetry::global::set_tracer_provider(provider.clone());
 
-    OpenTelemetryLayer::new(tracer).boxed()
+    (OpenTelemetryLayer::new(tracer).boxed(), provider)
 }
 
 fn stdout_layer<S>(

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -96,7 +96,15 @@ impl GrpcServer {
     }
 
     /// gRPC server running-task
-    pub async fn serve(self) -> crate::Result<()> {
+    ///
+    /// Serves until `shutdown` resolves, at which point tonic stops accepting new connections and
+    /// waits for in-flight requests to finish before returning. Dropping the service afterwards
+    /// stops the note streamer, which sends its subscribers a `GOAWAY` rather than having their
+    /// connections cut.
+    pub async fn serve_with_shutdown(
+        self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> crate::Result<()> {
         let (health_reporter, health_svc) = tonic_health::server::health_reporter();
         health_reporter.set_serving::<MidenNoteTransportServer<Self>>().await;
 
@@ -123,9 +131,13 @@ impl GrpcServer {
             .add_service(health_svc)
             .add_service(reflection_svc)
             .add_service(self.into_service())
-            .serve(addr)
+            .serve_with_shutdown(addr, shutdown)
             .await
-            .map_err(|e| crate::Error::Internal(format!("Server error: {e}")))
+            .map_err(|e| crate::Error::Internal(format!("Server error: {e}")))?;
+
+        tracing::info!("gRPC server drained");
+
+        Ok(())
     }
 }
 

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -42,6 +42,18 @@ use crate::metrics::MetricsGrpc;
 /// being an attack surface.
 const MAX_TAGS_PER_FETCH_REQUEST: usize = 128;
 
+/// How often the readiness probe asks the database whether it can still serve queries.
+///
+/// The probe is one trivial statement on a pooled connection, so it is cheap enough to run often;
+/// 5s bounds how long a wedged database can keep being advertised as healthy to roughly one
+/// load-balancer health-check interval.
+const READINESS_PROBE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default for [`GrpcServerConfig::shutdown_grace`].
+///
+/// Kubernetes' default readiness period is 10s, so one interval plus slack.
+const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(12);
+
 /// Miden Note Transport gRPC server
 pub struct GrpcServer {
     database: Arc<Database>,
@@ -63,6 +75,13 @@ pub struct GrpcServerConfig {
     pub max_connections: usize,
     /// Connection timeout in seconds
     pub request_timeout: usize,
+    /// How long to keep serving after reporting `NOT_SERVING`, before the drain begins
+    ///
+    /// Load balancers notice a status change on their own polling interval, not immediately.
+    /// Stopping the moment the status flips would black-hole whatever they route in between, so
+    /// this should cover at least one health-check interval of whatever fronts the service. Zero
+    /// drains immediately.
+    pub shutdown_grace: Duration,
 }
 
 /// Streaming task interface context
@@ -79,6 +98,7 @@ impl Default for GrpcServerConfig {
             max_note_size: 512_000,
             max_connections: 4096,
             request_timeout: 4,
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
         }
     }
 }
@@ -108,6 +128,29 @@ impl GrpcServer {
         let (health_reporter, health_svc) = tonic_health::server::health_reporter();
         health_reporter.set_serving::<MidenNoteTransportServer<Self>>().await;
 
+        // Keep the reported status honest for as long as we serve. Reporting SERVING once at
+        // startup and never revisiting it means a wedged database, a full disk or an exhausted
+        // connection pool all leave the process advertising itself as healthy, and load balancers
+        // keep routing into it.
+        let readiness =
+            tokio::spawn(readiness_probe(self.database.clone(), health_reporter.clone()));
+
+        // Flip to NOT_SERVING before the drain starts, and hold for the grace period, so that
+        // load balancers have a chance to take this instance out of rotation before it stops
+        // accepting.
+        let grace = self.config.shutdown_grace;
+        let shutdown = async move {
+            shutdown.await;
+
+            health_reporter.set_not_serving::<MidenNoteTransportServer<Self>>().await;
+            tracing::info!(
+                grace_secs = grace.as_secs(),
+                "Health set to NOT_SERVING, holding before drain"
+            );
+
+            tokio::time::sleep(grace).await;
+        };
+
         let reflection_svc = tonic_reflection::server::Builder::configure()
             .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
             .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
@@ -135,9 +178,36 @@ impl GrpcServer {
             .await
             .map_err(|e| crate::Error::Internal(format!("Server error: {e}")))?;
 
+        readiness.abort();
         tracing::info!("gRPC server drained");
 
         Ok(())
+    }
+}
+
+/// Keep the gRPC health status in step with whether the database can actually serve queries.
+///
+/// Runs until aborted, so a database that recovers flips the service back to SERVING without a
+/// restart.
+async fn readiness_probe(database: Arc<Database>, reporter: tonic_health::server::HealthReporter) {
+    let mut serving = true;
+
+    loop {
+        tokio::time::sleep(READINESS_PROBE_INTERVAL).await;
+
+        match database.health_check().await {
+            Ok(()) if !serving => {
+                reporter.set_serving::<MidenNoteTransportServer<GrpcServer>>().await;
+                serving = true;
+                tracing::info!("Database reachable again, health set to SERVING");
+            },
+            Err(e) if serving => {
+                reporter.set_not_serving::<MidenNoteTransportServer<GrpcServer>>().await;
+                serving = false;
+                tracing::error!(error = %e, "Database health check failed, health set to NOT_SERVING");
+            },
+            _ => {},
+        }
     }
 }
 

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -98,6 +98,8 @@ mod tests {
             grpc: GrpcServerConfig {
                 host: "127.0.0.1".into(),
                 port,
+                // Drain immediately; there is no load balancer to wait for.
+                shutdown_grace: std::time::Duration::ZERO,
                 ..Default::default()
             },
             database: DatabaseConfig::default(),

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -52,12 +52,44 @@ impl Node {
     }
 
     /// Node running-task
-    pub async fn entrypoint(self) {
+    ///
+    /// Returns the error that brought the server down, so that the process can exit non-zero and
+    /// supervisors configured to restart on failure actually restart it.
+    pub async fn entrypoint(self) -> Result<()> {
         info!("Starting Miden Transport Node");
         tokio::spawn(self.maintenance.entrypoint());
 
-        if let Err(e) = self.grpc.serve().await {
-            error!("Server error: {e}");
-        }
+        self.grpc.serve().await.inspect_err(|e| error!("Server error: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    /// A fatal server error must reach the caller rather than being logged and swallowed,
+    /// otherwise the process exits 0 and `restart: on-failure` never fires.
+    #[tokio::test]
+    async fn entrypoint_returns_the_error_that_brought_the_server_down() {
+        // Hold the port so that the node's own bind is guaranteed to fail.
+        let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = occupied.local_addr().unwrap().port();
+
+        let config = NodeConfig {
+            grpc: GrpcServerConfig {
+                host: "127.0.0.1".into(),
+                port,
+                ..Default::default()
+            },
+            database: DatabaseConfig::default(),
+        };
+
+        let node = Node::init(config).await.unwrap();
+
+        let err = node.entrypoint().await.unwrap_err();
+
+        assert!(err.to_string().contains("Server error"), "unexpected error: {err}");
     }
 }

--- a/crates/node/src/node/mod.rs
+++ b/crates/node/src/node/mod.rs
@@ -53,13 +53,32 @@ impl Node {
 
     /// Node running-task
     ///
+    /// Serves until `shutdown` resolves, then drains in-flight requests, stops the note streamer
+    /// and the maintenance loop, and returns.
+    ///
     /// Returns the error that brought the server down, so that the process can exit non-zero and
     /// supervisors configured to restart on failure actually restart it.
-    pub async fn entrypoint(self) -> Result<()> {
+    pub async fn entrypoint(
+        self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> Result<()> {
         info!("Starting Miden Transport Node");
-        tokio::spawn(self.maintenance.entrypoint());
+        let maintenance = tokio::spawn(self.maintenance.entrypoint());
 
-        self.grpc.serve().await.inspect_err(|e| error!("Server error: {e}"))
+        let result = self
+            .grpc
+            .serve_with_shutdown(shutdown)
+            .await
+            .inspect_err(|e| error!("Server error: {e}"));
+
+        // The maintenance loop spends almost all of its time sleeping between cleanup passes and
+        // holds no client-visible state, so there is nothing to drain — aborting it mid-sleep is
+        // the intended stop. A cleanup pass interrupted mid-transaction rolls back, and the next
+        // start picks the same expired rows up again.
+        maintenance.abort();
+        info!("Maintenance loop stopped");
+
+        result
     }
 }
 
@@ -69,6 +88,45 @@ mod tests {
 
     use super::*;
 
+    /// Bind to port 0 to reserve a free port, then release it for the node to claim.
+    fn free_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+    }
+
+    fn test_config(port: u16) -> NodeConfig {
+        NodeConfig {
+            grpc: GrpcServerConfig {
+                host: "127.0.0.1".into(),
+                port,
+                ..Default::default()
+            },
+            database: DatabaseConfig::default(),
+        }
+    }
+
+    /// The node must come back on its own once the shutdown signal fires. Before this, `serve`
+    /// ran until the process was killed, so SIGTERM cut in-flight work instead of draining it.
+    #[tokio::test]
+    async fn entrypoint_returns_once_the_shutdown_signal_fires() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let node = Node::init(test_config(free_port())).await.unwrap();
+
+        let running = tokio::spawn(node.entrypoint(async {
+            let _ = rx.await;
+        }));
+
+        // Let the server reach its accept loop before asking it to stop.
+        tokio::task::yield_now().await;
+        tx.send(()).unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), running)
+            .await
+            .expect("entrypoint must return after the shutdown signal")
+            .unwrap();
+
+        assert!(result.is_ok(), "a signalled shutdown is not a failure: {result:?}");
+    }
+
     /// A fatal server error must reach the caller rather than being logged and swallowed,
     /// otherwise the process exits 0 and `restart: on-failure` never fires.
     #[tokio::test]
@@ -77,18 +135,9 @@ mod tests {
         let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = occupied.local_addr().unwrap().port();
 
-        let config = NodeConfig {
-            grpc: GrpcServerConfig {
-                host: "127.0.0.1".into(),
-                port,
-                ..Default::default()
-            },
-            database: DatabaseConfig::default(),
-        };
+        let node = Node::init(test_config(port)).await.unwrap();
 
-        let node = Node::init(config).await.unwrap();
-
-        let err = node.entrypoint().await.unwrap_err();
+        let err = node.entrypoint(std::future::pending()).await.unwrap_err();
 
         assert!(err.to_string().contains("Server error"), "unexpected error: {err}");
     }

--- a/crates/node/src/shutdown.rs
+++ b/crates/node/src/shutdown.rs
@@ -1,0 +1,37 @@
+//! Process shutdown signalling.
+
+use tracing::info;
+
+/// Resolves when the process is asked to terminate.
+///
+/// Listens for `SIGTERM` — what Kubernetes and `docker stop` send — and for `SIGINT` via
+/// `Ctrl-C`, so an operator gets the same drain in both cases. On non-Unix targets only
+/// `Ctrl-C` is available.
+///
+/// # Panics
+/// Panics if the signal handlers cannot be installed, which means the process cannot be
+/// terminated cleanly and should not pretend otherwise.
+pub async fn signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to install the SIGTERM handler");
+        let mut sigint =
+            signal(SignalKind::interrupt()).expect("failed to install the SIGINT handler");
+
+        let received = tokio::select! {
+            _ = sigterm.recv() => "SIGTERM",
+            _ = sigint.recv() => "SIGINT",
+        };
+
+        info!(signal = received, "Shutdown signal received");
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await.expect("failed to install the Ctrl-C handler");
+        info!(signal = "Ctrl-C", "Shutdown signal received");
+    }
+}


### PR DESCRIPTION
Closes #127

Draft while I wait to be assigned on the issue.

> Contains #137 (#126) and #142 (#119) as earlier commits — the NOT_SERVING transition needs a shutdown path to hang off. Please merge those first and this will rebase down. Review the top commit.

## Rationale

`set_serving` was called once at startup and the reporter then dropped, so the status never changed again. A wedged database, a full disk or an exhausted connection pool all left the process advertising itself as healthy while load balancers kept routing into a black hole. As the issue says, the health service existing at all is already right — this is about not lying with it.

## Changes

`Database::health_check` takes a pool connection and runs a trivial statement, so it fails when the pool is exhausted or the database is unreachable, not only when the process is dead. A probe task runs it every 5s and moves the status in *both* directions, so a database that recovers brings the node back without a restart.

Shutdown flips to NOT_SERVING before the drain begins and holds for `--shutdown-grace-secs` before tonic stops accepting.

On that flag: load balancers notice a status change on their own polling interval, so stopping the instant the status flips black-holes whatever they route in between — which would undo much of the point of draining at all. The default of 12s covers one Kubernetes readiness period plus slack, and 0 drains immediately. I made it configurable rather than constant because the right value depends on what fronts the deployment, but it is a new CLI flag, so happy to fold it back into a constant if you'd rather not grow the surface.

## Tests

- `health_check_passes_on_a_reachable_database`
- `health_check_fails_when_the_pool_cannot_serve` — closes the pool, which is the closest stand-in for a wedged database, and asserts the probe catches it. This is precisely the case that used to go unnoticed.

## Checks

Full test suite passes, clippy is clean over the workspace, and `cargo fmt --check` with `configs/rustfmt.toml` reports nothing in the touched files.
