### PR TITLE
fix: advance fetch_notes rcursor from effective legacy cursor

### DIFF
--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -5,6 +5,7 @@ mod sqlite;
 pub use self::error::DatabaseError;
 pub use self::maintenance::DatabaseMaintenance;
 use self::sqlite::SqliteDatabase;
+pub(crate) use self::sqlite::{LEGACY_CURSOR_THRESHOLD, effective_fetch_cursor};
 use crate::metrics::MetricsDatabase;
 use crate::types::{NoteId, NoteTag, StoredNote};
 

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -29,7 +29,18 @@ pub(crate) const FETCH_NOTES_BATCH_SIZE: i64 = 500;
 /// which at realistic insert rates is decades). 10^12 is two orders of magnitude
 /// above any plausible `seq` value we'd reach in the lifetime of this deployment,
 /// and two orders of magnitude below any microsecond timestamp this decade.
-const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
+pub(crate) const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
+
+/// Map a client cursor to the effective pagination cursor used for filtering
+/// and response advancement.
+///
+/// Legacy microsecond-timestamp cursors (above [`LEGACY_CURSOR_THRESHOLD`]) are
+/// treated as `0`. Callers that compute a response/`rcursor` must start from
+/// this value — not the raw request cursor — otherwise a legacy client loops
+/// on the same first batch forever (`max(1.7e15, seq) == 1.7e15`).
+pub(crate) fn effective_fetch_cursor(cursor: u64) -> u64 {
+    if cursor > LEGACY_CURSOR_THRESHOLD { 0 } else { cursor }
+}
 
 /// `SQLite` implementation of the database backend
 pub struct SqliteDatabase {
@@ -157,13 +168,13 @@ impl DatabaseBackend for SqliteDatabase {
         // carry microsecond-timestamp cursors; interpret those as 0 so they
         // don't stall forever waiting for `seq` to catch up. Record a metric
         // so operators can see when pre-migration clients are being reset.
-        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD {
+        // Response cursors must also start from this effective value (see
+        // gRPC `fetch_notes` / streamer) or pagination never converges.
+        let effective_cursor = effective_fetch_cursor(cursor);
+        if effective_cursor != cursor {
             self.metrics.db_fetch_notes_legacy_cursor_reset();
             tracing::info!(original_cursor = cursor, "Legacy cursor reset to 0");
-            0
-        } else {
-            cursor
-        };
+        }
 
         let cursor_i64: i64 = effective_cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -258,7 +258,10 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
-        let mut rcursor = cursor;
+        // Start from the effective cursor (legacy timestamps → 0). Using the
+        // raw request cursor here left `rcursor ≈ 1.7e15` after a DB-side reset,
+        // so the client re-sent the same cursor and looped on the first batch.
+        let mut rcursor = crate::database::effective_fetch_cursor(cursor);
         for stored_note in &stored_notes {
             let seq_cursor: u64 = stored_note
                 .seq
@@ -393,5 +396,93 @@ mod tests {
         let response = result.expect("request at the cap must succeed").into_inner();
         assert_eq!(response.notes.len(), 0, "DB is empty, no notes returned");
         assert_eq!(response.cursor, 0);
+    }
+
+    /// Regression for #130: DB resets legacy microsecond cursors to 0 for the
+    /// query, but the response cursor must also start from that effective
+    /// value. Otherwise `rcursor = max(1.7e15, seq)` stays legacy and the
+    /// client permanently re-downloads the first batch.
+    #[tokio::test]
+    async fn test_fetch_notes_legacy_cursor_advances() {
+        use chrono::Utc;
+
+        use crate::database::LEGACY_CURSOR_THRESHOLD;
+        use crate::test_utils::{TAG_LOCAL_ANY, test_note_header};
+        use crate::types::StoredNote;
+
+        let server = test_server().await;
+
+        server
+            .database
+            .store_note(&StoredNote {
+                header: test_note_header(),
+                details: vec![1, 2, 3, 4],
+                created_at: Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap();
+
+        let legacy_cursor: u64 = 1_760_000_000_000_000;
+        assert!(legacy_cursor > LEGACY_CURSOR_THRESHOLD);
+
+        let first = server
+            .fetch_notes(tonic::Request::new(FetchNotesRequest {
+                tags: vec![TAG_LOCAL_ANY],
+                cursor: legacy_cursor,
+            }))
+            .await
+            .expect("legacy cursor fetch must succeed")
+            .into_inner();
+
+        assert_eq!(first.notes.len(), 1, "legacy cursor should return notes after reset");
+        assert!(
+            first.cursor > 0 && first.cursor <= LEGACY_CURSOR_THRESHOLD,
+            "response cursor must be a seq, not the legacy timestamp; got {}",
+            first.cursor
+        );
+
+        let second = server
+            .fetch_notes(tonic::Request::new(FetchNotesRequest {
+                tags: vec![TAG_LOCAL_ANY],
+                cursor: first.cursor,
+            }))
+            .await
+            .expect("follow-up fetch must succeed")
+            .into_inner();
+
+        assert!(
+            second.notes.is_empty(),
+            "after advancing past the note seq, the same note must not be returned again"
+        );
+        assert_eq!(second.cursor, first.cursor);
+    }
+
+    /// Empty DB + legacy cursor: response cursor must reset to 0 so the client
+    /// converges even when the first page has no notes.
+    #[tokio::test]
+    async fn test_fetch_notes_legacy_cursor_empty_resets_rcursor() {
+        use crate::database::LEGACY_CURSOR_THRESHOLD;
+        use crate::test_utils::TAG_LOCAL_ANY;
+
+        let server = test_server().await;
+        let legacy_cursor: u64 = 1_760_000_000_000_000;
+        assert!(legacy_cursor > LEGACY_CURSOR_THRESHOLD);
+
+        let response = server
+            .fetch_notes(tonic::Request::new(FetchNotesRequest {
+                tags: vec![TAG_LOCAL_ANY],
+                cursor: legacy_cursor,
+            }))
+            .await
+            .expect("legacy cursor fetch must succeed")
+            .into_inner();
+
+        assert!(response.notes.is_empty());
+        assert_eq!(
+            response.cursor, 0,
+            "empty response must still return the effective cursor, not the legacy timestamp"
+        );
     }
 }

--- a/crates/node/src/node/grpc/streaming.rs
+++ b/crates/node/src/node/grpc/streaming.rs
@@ -95,7 +95,9 @@ impl NoteStreamerManager {
         let mut updates = vec![];
         for (tag, tag_data) in &self.tags {
             let snotes = self.database.fetch_notes(*tag, tag_data.cursor).await?;
-            let mut cursor = tag_data.cursor;
+            // Match pull-side `fetch_notes`: advance from the effective cursor
+            // so a legacy microsecond timestamp does not pin the stream forever.
+            let mut cursor = crate::database::effective_fetch_cursor(tag_data.cursor);
             for snote in &snotes {
                 // Advance cursor using the DB-assigned monotonic `seq`
                 // (matches the pull-side fetch_notes contract). Using


### PR DESCRIPTION
Legacy microsecond cursors get reset to 0 in the DB layer, but `fetch_notes` (and the streamer) were still advancing `rcursor` from the raw request cursor so clients kept getting the first page.

Shared `effective_fetch_cursor` and start response cursors from that. Added regression tests.
