### PR TITLE
fix: refuse missing SQLite file unless --create-database

### DIFF
--- a/bin/node/docker/docker-compose.yml
+++ b/bin/node/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: bin/node/docker/Dockerfile
     ports:
       - "57292:57292"  # gRPC
-    command: ["miden-note-transport-node", "--host", "0.0.0.0", "--database-url", "/app/data/node.db"]
+    command: ["miden-note-transport-node", "--host", "0.0.0.0", "--database-url", "/app/data/node.db", "--create-database"]
     environment:
       - JSON_LOGGING=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -21,6 +21,13 @@ struct Args {
     #[arg(long, default_value = ":memory:")]
     database_url: String,
 
+    /// Create the database file if it does not exist (file-backed URLs only).
+    ///
+    /// Without this flag, a missing path fails startup instead of silently
+    /// creating an empty database (which would reset the note sequence space).
+    #[arg(long, default_value_t = false)]
+    create_database: bool,
+
     /// Retention period in days
     #[arg(long, default_value = "30")]
     retention_days: u32,
@@ -73,6 +80,7 @@ async fn main() -> Result<()> {
         database: DatabaseConfig {
             url: args.database_url,
             retention_days: args.retention_days,
+            create_database: args.create_database,
         },
     };
 

--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -62,6 +62,13 @@ pub struct DatabaseConfig {
     pub url: String,
     /// Retention period in days
     pub retention_days: u32,
+    /// When `true`, create the SQLite file if it does not exist.
+    ///
+    /// File-backed URLs refuse to start when the path is missing unless this
+    /// flag is set. Prevents a wrong `--database-url` (or an unmounted volume)
+    /// from silently creating an empty DB and resetting the `seq` space.
+    /// Ignored for `:memory:` / `file::memory:` URLs.
+    pub create_database: bool,
 }
 
 impl Default for DatabaseConfig {
@@ -69,6 +76,7 @@ impl Default for DatabaseConfig {
         Self {
             url: ":memory:".to_string(),
             retention_days: 30,
+            create_database: false,
         }
     }
 }

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -83,12 +83,6 @@ impl DatabaseBackend for SqliteDatabase {
         config: DatabaseConfig,
         metrics: MetricsDatabase,
     ) -> Result<Self, DatabaseError> {
-        if !std::path::Path::new(&config.url).exists() && !config.url.contains(":memory:") {
-            std::fs::File::create(&config.url).map_err(|e| {
-                DatabaseError::Configuration(format!("Failed to create database file: {e}"))
-            })?;
-        }
-
         // SQLite `:memory:` DBs are per-connection-isolated — two connections
         // pointing at `:memory:` see two different databases. With a pool of N
         // connections, writes splinter across N isolated DBs and most reads
@@ -104,6 +98,19 @@ impl DatabaseBackend for SqliteDatabase {
         // driver default). For file-backed URLs, a large pool is appropriate
         // since all connections open the same file.
         let is_in_memory = config.url == ":memory:" || config.url.starts_with("file::memory:");
+
+        if !is_in_memory && !std::path::Path::new(&config.url).exists() {
+            if !config.create_database {
+                return Err(DatabaseError::Configuration(format!(
+                    "Database file does not exist: {}. Pass --create-database to create it on first run.",
+                    config.url
+                )));
+            }
+            std::fs::File::create(&config.url).map_err(|e| {
+                DatabaseError::Configuration(format!("Failed to create database file: {e}"))
+            })?;
+        }
+
         let max_size = if is_in_memory { 1 } else { 16 };
 
         let manager = ConnectionManager::new(&config.url);
@@ -258,5 +265,103 @@ impl DatabaseBackend for SqliteDatabase {
             .await?;
 
         Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Metrics;
+
+    fn unique_db_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "miden-nts-{}-{}-{}.db",
+            label,
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ))
+    }
+
+    #[tokio::test]
+    async fn refuse_missing_database_file_without_create_flag() {
+        let path = unique_db_path("missing-refuse");
+        let _ = std::fs::remove_file(&path);
+        assert!(!path.exists());
+
+        let result = SqliteDatabase::connect(
+            DatabaseConfig {
+                url: path.to_string_lossy().into_owned(),
+                retention_days: 30,
+                create_database: false,
+            },
+            Metrics::default().db,
+        )
+        .await;
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("missing file must fail without --create-database"),
+        };
+
+        assert!(
+            matches!(err, DatabaseError::Configuration(_)),
+            "expected Configuration error, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("does not exist"),
+            "error should mention missing file: {err}"
+        );
+        assert!(!path.exists(), "must not create the file on refuse");
+    }
+
+    #[tokio::test]
+    async fn create_missing_database_file_with_create_flag() {
+        let path = unique_db_path("missing-create");
+        let _ = std::fs::remove_file(&path);
+        assert!(!path.exists());
+
+        let db = SqliteDatabase::connect(
+            DatabaseConfig {
+                url: path.to_string_lossy().into_owned(),
+                retention_days: 30,
+                create_database: true,
+            },
+            Metrics::default().db,
+        )
+        .await
+        .expect("create_database should allow first-run file creation");
+
+        assert!(path.exists(), "database file should have been created");
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn connect_existing_database_file_without_create_flag() {
+        let path = unique_db_path("existing");
+        std::fs::File::create(&path).expect("pre-create empty file");
+
+        let db = SqliteDatabase::connect(
+            DatabaseConfig {
+                url: path.to_string_lossy().into_owned(),
+                retention_days: 30,
+                create_database: false,
+            },
+            Metrics::default().db,
+        )
+        .await
+        .expect("existing file must connect without create_database");
+
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn memory_url_ignores_create_database_flag() {
+        // Regression: `:memory:` must keep working with create_database=false
+        // (the default). The missing-file guard must not apply to in-memory URLs.
+        let db = SqliteDatabase::connect(DatabaseConfig::default(), Metrics::default().db)
+            .await
+            .expect(":memory: connect must succeed without create_database");
+        drop(db);
     }
 }

--- a/docs/external/src/operators.md
+++ b/docs/external/src/operators.md
@@ -32,8 +32,11 @@ miden-note-transport-node \
   --host 0.0.0.0 \
   --port 57292 \
   --database-url /var/lib/miden-note-transport/node.db \
+  --create-database \
   --retention-days 30
 ```
+
+On first run with a file-backed `--database-url`, pass `--create-database`. Without it, a missing path fails startup instead of silently creating an empty database (which would reset the note sequence space). After the file exists, omit the flag so a wrong path or deleted volume cannot recreate an empty DB unnoticed.
 
 ## CLI flags
 
@@ -42,6 +45,7 @@ miden-note-transport-node \
 | `--host` | `127.0.0.1` | Address to bind to. |
 | `--port` | `57292` | gRPC port. |
 | `--database-url` | `:memory:` | SQLite database URL or file path. Use a file path for persistence. |
+| `--create-database` | off | Create the SQLite file if missing (file-backed URLs only). Required for first run. |
 | `--retention-days` | `30` | How long to retain notes before cleanup. |
 | `--max-note-size` | `512000` | Maximum note details size in bytes. |
 | `--max-connections` | `4096` | Maximum concurrent gRPC connections. |
@@ -94,7 +98,7 @@ make docker-node-down
 
 to stop the stack.
 
-The Compose node service passes `--database-url /app/data/node.db` and mounts `/app/data` on the `node_data` volume, so note storage survives container restarts.
+The Compose node service passes `--database-url /app/data/node.db --create-database` and mounts `/app/data` on the `node_data` volume, so note storage survives container restarts and a fresh volume can initialize the file on first start.
 
 ## Ports
 

--- a/docs/src/operator/usage.md
+++ b/docs/src/operator/usage.md
@@ -12,8 +12,11 @@ For example,
 miden-note-transport-node \
   --host 0.0.0.0 \
   --port 57292 \
-  --database-url mtln.db
+  --database-url mtln.db \
+  --create-database
 ```
+
+Use `--create-database` only on first run (or when intentionally creating a new file). A missing file-backed path without this flag fails startup instead of silently creating an empty database.
 
 > [!NOTE]
 > `miden-note-transport-node` provides default arguments aimed at development.


### PR DESCRIPTION
A wrong or missing --database-url used to silently create an empty SQLite file and reset seq from 1. Startup now fails if the file is absent, unless --create-database is set. :memory: is unchanged.

Closes #124