### PR TITLE
fix(docker): run as non-root with HEALTHCHECK and harden compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,5 @@ docker-run-node: ## Runs the node as a Docker container
 	docker run --name miden-note-transport-node \
 			   -p 57292:57292 \
                -v node-db:/db \
-               -d miden-note-transport-node
+               -d miden-note-transport-node \
+               miden-note-transport-node --host 0.0.0.0 --database-url /db/node.db

--- a/bin/node/docker/Dockerfile
+++ b/bin/node/docker/Dockerfile
@@ -17,13 +17,29 @@ RUN cargo install --path bin/node --locked
 
 FROM debian:bookworm-slim
 
+# TARGETARCH is set by BuildKit (amd64/arm64). Plain `docker build` defaults to amd64.
+ARG TARGETARCH=amd64
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.54
+
 # Update machine & install required packages
 # The installation of libsqlite3-0 is needed because the binary is linked against it
+# grpc_health_probe is bundled for Docker HEALTHCHECK / orchestrator probes
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-    libsqlite3-0 \
-    && rm -rf /var/lib/apt/lists/*
+        libsqlite3-0 \
+        ca-certificates \
+        curl \
+    && curl -fsSL -o /usr/local/bin/grpc_health_probe \
+        "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" \
+    && chmod +x /usr/local/bin/grpc_health_probe \
+    && apt-get purge -y curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 miden \
+    && useradd --uid 10001 --gid miden --shell /usr/sbin/nologin --no-create-home miden \
+    && mkdir -p /db /app/data \
+    && chown -R miden:miden /db /app/data
 
 COPY --from=builder /usr/local/cargo/bin/miden-note-transport-node /usr/local/bin/miden-note-transport-node
 
@@ -41,7 +57,13 @@ LABEL org.opencontainers.image.created=$CREATED \
     org.opencontainers.image.version=$VERSION \
     org.opencontainers.image.revision=$COMMIT
 
+USER miden
+
 # Expose port
 EXPOSE 57292
+
+# gRPC health is served on the same port as the API (see tonic-health registration).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD grpc_health_probe -addr=127.0.0.1:57292 || exit 1
 
 CMD ["miden-note-transport-node", "--host", "0.0.0.0"]

--- a/bin/node/docker/docker-compose.yml
+++ b/bin/node/docker/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     ports:
       - "57292:57292"  # gRPC
     command: ["miden-note-transport-node", "--host", "0.0.0.0", "--database-url", "/app/data/node.db"]
+    restart: unless-stopped
     environment:
       - JSON_LOGGING=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - OTEL_SERVICE_NAME=miden-note-transport-node
       - RUST_LOG=INFO
       - DOCKER_ENV=true
@@ -23,7 +23,8 @@ services:
 
   # OpenTelemetry Collector
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.158.0
+    restart: unless-stopped
     volumes:
       - ./bin/node/docker/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
@@ -39,7 +40,8 @@ services:
 
   # Traces
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.4
+    restart: unless-stopped
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./bin/node/docker/tempo.yaml:/etc/tempo.yaml:ro
@@ -50,7 +52,8 @@ services:
 
   # Metrics
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.2
+    restart: unless-stopped
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     volumes:
@@ -65,11 +68,12 @@ services:
 
   # Visualization
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4.8
+    restart: unless-stopped
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
Hardens the node container and local compose stack.

Final image runs as uid 10001 with grpc_health_probe HEALTHCHECK on :57292. Compose gets restart: unless-stopped, pinned observability tags, Grafana password from env, and drops the unused OTEL_EXPORTER_OTLP_PROTOCOL var. make docker-run-node now passes --database-url /db/node.db so the volume is actually used.

Grafana dashboard provisioning left to #94.

Closes #133