### PR TITLE
fix: make legacy cursor reset converge

### DIFF
--- a/crates/node/src/database/mod.rs
+++ b/crates/node/src/database/mod.rs
@@ -8,6 +8,23 @@ use self::sqlite::SqliteDatabase;
 use crate::metrics::MetricsDatabase;
 use crate::types::{NoteId, NoteTag, StoredNote};
 
+/// Threshold above which a fetch cursor is interpreted as a legacy
+/// microsecond-timestamp cursor from the pre-`seq` schema and reset to 0.
+///
+/// Before the `seq`-cursor migration, cursors were `created_at.timestamp_micros()`
+/// with values near 1.7×10^15. After migration, cursors are `seq` values starting
+/// at 1. Without this reset, any client that stored a cursor before migration
+/// would see zero notes forever (until `seq` caught up to their old timestamp,
+/// which at realistic insert rates is decades). 10^12 is two orders of magnitude
+/// above any plausible `seq` value we'd reach in the lifetime of this deployment,
+/// and two orders of magnitude below any microsecond timestamp this decade.
+const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
+
+/// Converts a pre-`seq` timestamp cursor to the beginning of the `seq` cursor space.
+pub(crate) fn normalize_legacy_cursor(cursor: u64) -> u64 {
+    if cursor > LEGACY_CURSOR_THRESHOLD { 0 } else { cursor }
+}
+
 /// Database operations
 #[async_trait::async_trait]
 pub trait DatabaseBackend: Send + Sync {

--- a/crates/node/src/database/sqlite/mod.rs
+++ b/crates/node/src/database/sqlite/mod.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use diesel::prelude::*;
 
-use crate::database::{DatabaseBackend, DatabaseConfig, DatabaseError};
+use crate::database::{DatabaseBackend, DatabaseConfig, DatabaseError, normalize_legacy_cursor};
 use crate::metrics::MetricsDatabase;
 use crate::types::{NoteId, NoteTag, StoredNote};
 
@@ -18,18 +18,6 @@ use models::{NewNote, Note};
 /// deserialized batch) regardless of how far behind the client's cursor is. A
 /// backlogged client paginates naturally by re-calling with the returned cursor.
 pub(crate) const FETCH_NOTES_BATCH_SIZE: i64 = 500;
-
-/// Threshold above which a `fetch_notes` cursor is interpreted as a legacy
-/// microsecond-timestamp cursor from the pre-`seq` schema and reset to 0.
-///
-/// Before the `seq`-cursor migration, cursors were `created_at.timestamp_micros()`
-/// — values near 1.7×10^15. After migration, cursors are `seq` values starting
-/// at 1. Without this reset, any client that stored a cursor before migration
-/// would see zero notes forever (until `seq` caught up to their old timestamp,
-/// which at realistic insert rates is decades). 10^12 is two orders of magnitude
-/// above any plausible `seq` value we'd reach in the lifetime of this deployment,
-/// and two orders of magnitude below any microsecond timestamp this decade.
-const LEGACY_CURSOR_THRESHOLD: u64 = 1_000_000_000_000;
 
 /// `SQLite` implementation of the database backend
 pub struct SqliteDatabase {
@@ -157,13 +145,11 @@ impl DatabaseBackend for SqliteDatabase {
         // carry microsecond-timestamp cursors; interpret those as 0 so they
         // don't stall forever waiting for `seq` to catch up. Record a metric
         // so operators can see when pre-migration clients are being reset.
-        let effective_cursor = if cursor > LEGACY_CURSOR_THRESHOLD {
+        let effective_cursor = normalize_legacy_cursor(cursor);
+        if effective_cursor != cursor {
             self.metrics.db_fetch_notes_legacy_cursor_reset();
             tracing::info!(original_cursor = cursor, "Legacy cursor reset to 0");
-            0
-        } else {
-            cursor
-        };
+        }
 
         let cursor_i64: i64 = effective_cursor.try_into().map_err(|_| {
             DatabaseError::QueryExecution("Cursor too large for SQLite".to_string())

--- a/crates/node/src/node/grpc/mod.rs
+++ b/crates/node/src/node/grpc/mod.rs
@@ -27,7 +27,7 @@ use tower::timeout::TimeoutLayer;
 use tower_http::cors::{Any, CorsLayer};
 
 use self::streaming::{NoteStreamer, StreamerMessage, Sub, Subface};
-use crate::database::Database;
+use crate::database::{Database, normalize_legacy_cursor};
 use crate::metrics::MetricsGrpc;
 
 /// Upper bound on the number of tags a client may include in a single
@@ -258,7 +258,7 @@ impl miden_note_transport_proto::miden_note_transport::miden_note_transport_serv
             .await
             .map_err(|e| tonic::Status::internal(format!("Failed to fetch notes: {e:?}")))?;
 
-        let mut rcursor = cursor;
+        let mut rcursor = normalize_legacy_cursor(cursor);
         for stored_note in &stored_notes {
             let seq_cursor: u64 = stored_note
                 .seq
@@ -349,6 +349,8 @@ mod tests {
     use super::*;
     use crate::database::{Database, DatabaseConfig};
     use crate::metrics::Metrics;
+    use crate::test_utils::{TAG_LOCAL_ANY, test_note_header};
+    use crate::types::StoredNote;
 
     async fn test_server() -> GrpcServer {
         let metrics = Metrics::default();
@@ -393,5 +395,49 @@ mod tests {
         let response = result.expect("request at the cap must succeed").into_inner();
         assert_eq!(response.notes.len(), 0, "DB is empty, no notes returned");
         assert_eq!(response.cursor, 0);
+    }
+
+    /// A pre-`seq` timestamp cursor must converge into the current cursor
+    /// space in the response as well as in the database query.
+    ///
+    /// Regression test for #130: the database already treated a legacy cursor
+    /// as 0, but the gRPC handler initialized the response cursor from the
+    /// original timestamp. That caused clients to request the same first page
+    /// forever.
+    #[tokio::test]
+    async fn test_fetch_notes_legacy_cursor_converges() {
+        let server = test_server().await;
+
+        server
+            .database
+            .store_note(&StoredNote {
+                header: test_note_header(),
+                details: vec![1, 2, 3, 4],
+                created_at: chrono::Utc::now(),
+                seq: 0,
+                after_block_num: None,
+            })
+            .await
+            .unwrap();
+
+        let legacy_cursor = 1_760_000_000_000_000;
+        let request = tonic::Request::new(FetchNotesRequest {
+            tags: vec![TAG_LOCAL_ANY],
+            cursor: legacy_cursor,
+        });
+        let response = server.fetch_notes(request).await.unwrap().into_inner();
+
+        assert_eq!(response.notes.len(), 1);
+        assert!(response.cursor > 0);
+        assert!(response.cursor < legacy_cursor);
+
+        let retry = tonic::Request::new(FetchNotesRequest {
+            tags: vec![TAG_LOCAL_ANY],
+            cursor: response.cursor,
+        });
+        let retry_response = server.fetch_notes(retry).await.unwrap().into_inner();
+
+        assert!(retry_response.notes.is_empty());
+        assert_eq!(retry_response.cursor, response.cursor);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #130.

Legacy pre-`seq` cursors are already normalized to `0` by the SQLite fetch path, but the gRPC handler initialized the response cursor from the original request cursor. For timestamp-shaped legacy cursors, that meant the database returned the first page while the response kept the old ~10^15 cursor, so the next request fetched the same page again indefinitely.

This change:

- centralizes legacy cursor normalization in the database module;
- uses the same normalization for the gRPC response cursor;
- preserves the existing legacy-cursor metric and logging in the SQLite path;
- adds a regression test verifying that a legacy cursor converges into the `seq` cursor space and the next fetch progresses normally.

## Testing

- `cargo test -p miden-note-transport-node test_fetch_notes_legacy_cursor_converges --locked`
- `cargo test --workspace --locked`
- `cargo clippy --locked --all-targets --workspace -- -D warnings`
- `cargo +nightly fmt --all --check -- --config-path configs/rustfmt.toml`

All checks pass.