### PR TITLE
fix: update repository metadata and badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude      = [".github/"]
 homepage     = "https://miden.xyz"
 license      = "MIT"
 readme       = "README.md"
-repository   = "https://github.com/0xMiden/miden-note-transport"
+repository   = "https://github.com/0xMiden/note-transport-service"
 rust-version = "1.96.1"
 version      = "0.5.0-alpha.1"
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Miden Note Transport Layer
 
-<!--`TODO(template) update badges`-->
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/project-template/blob/main/LICENSE)
-[![test](https://github.com/0xMiden/project-template/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/project-template/actions/workflows/test.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.89+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/note-transport-service/blob/main/LICENSE)
+[![test](https://github.com/0xMiden/note-transport-service/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/note-transport-service/actions/workflows/test.yml)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.96.1+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 
 ## Overview
 


### PR DESCRIPTION
Summary
Updates stale repository metadata and README badges for note-transport-service.

Fixes #148.

Why
The README still had template badge references pointing at `0xMiden/project-template`, and its Rust version badge showed `1.89+` while the workspace requires Rust `1.96.1`. The workspace `repository` field also pointed at the old `miden-note-transport` path instead of the canonical `note-transport-service` repository.

Changes
- Removed the stale `TODO(template) update badges` comment.
- Updated README license and test badges to point at `0xMiden/note-transport-service`.
- Updated the README Rust version badge to `1.96.1+`, matching the workspace `rust-version`.
- Updated the workspace `repository` metadata to `https://github.com/0xMiden/note-transport-service`.

Testing
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p miden-note-transport-proto-build`

I also tried `cargo check --workspace`; it progressed into dependencies but failed in the existing `miden-core-lib` build script with `invalid root module path 'mod.masm': The system cannot find the file specified`. That appears unrelated to this metadata/README change.